### PR TITLE
:construction_worker: Append daily updates without rewriting history

### DIFF
--- a/.github/workflows/update-automation.yml
+++ b/.github/workflows/update-automation.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: false # No need to fetch the bulk data for this workflow
-          fetch-depth: 2 # Fetch enough history to reference HEAD~
 
       # Step 2: Set up uv and Python 3.14.7
       - name: Set up uv
@@ -53,31 +52,16 @@ jobs:
             --historical-tail tests/fixtures/historical_tail.csv \
             --updates data/updates/btcusd_bitstamp_1min_latest.csv
 
-      # Step 6: Check previous commit message
-      - name: Check previous commit message
-        if: env.SCRIPT_SUCCESS == 'true'
-        run: |
-          LAST_COMMIT_MSG=$(git log -1 --pretty=%B)
-          if [[ "$LAST_COMMIT_MSG" == ":package: Daily update"* ]]; then
-            echo "Previous commit is a daily update. Preparing to overwrite."
-            echo "RESET_PREVIOUS_COMMIT=true" >> "$GITHUB_ENV"
-          else
-            echo "RESET_PREVIOUS_COMMIT=false" >> "$GITHUB_ENV"
-          fi
-
-      # Step 7: Commit and force push if previous commit was a daily update
+      # Step 6: Commit and push the validated daily update
       - name: Commit and Push Updates
         if: env.SCRIPT_SUCCESS == 'true'
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          if [ "$RESET_PREVIOUS_COMMIT" == "true" ]; then
-            git reset HEAD~ # Drop the previous commit
-          fi
           git add data/updates/btcusd_bitstamp_1min_latest.csv
-          git commit -m ":package: Daily update: $(date -u +'%Y-%m-%d')"
-          if [ "$RESET_PREVIOUS_COMMIT" == "true" ]; then
-            git push -f origin main # Force push to overwrite the previous commit
-          else
-            git push origin main
+          if git diff --cached --quiet; then
+            echo "No dataset changes to publish."
+            exit 0
           fi
+          git commit -m ":package: Daily update: $(date -u +'%Y-%m-%d')"
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -51,33 +51,31 @@ Or, just download the individual datasets:
 
 ### Keeping the Data Up-to-Date
 
-Some time passes and you want to fetch the new daily updates. Perform a force pull:
+Daily updates are ordinary commits. After cloning, fetch new minutes with `git pull`.
+
+Previously (before 2026-08-28), data was kept up-to-date by overwriting the git history.
+If your clone still tracks this older workflow, then run this once, and use `git pull` thereafter:
 
 ```bash
 git fetch upstream
 git reset --hard upstream/main
 ```
 
-This is needed instead of `git pull`, because the daily update file gets overwritten to keep the git history clean.
-
 ## Working with the Data in Python
 
-Assuming you have [Python installed](https://www.python.org/downloads/release/python-3129/),
-you can install Poetry and the project dependencies:
+Assuming you have [Python 3.11+](https://www.python.org/downloads/) and
+[uv](https://docs.astral.sh/uv/), install the project dependencies from
+the repository root:
 
 ```bash
-python -m venv venv  # Create a new virtual environment
-source venv/bin/activate  # On Windows use `venv\Scripts\activate`
-
-pip install poetry  # Install Poetry
-poetry install  # Install the project dependencies
+uv sync
 ```
 
 We have a [sample script](scripts/inspect_data.py) for you to inspect the data integrity
 (validate that there are no missing minutes, no duplicates, no nulls, etc):
 
 ```bash
-python -m scripts.inspect_data merged
+uv run python -m scripts.inspect_data merged
 ```
 
 Replace `merged` with `bulk` or `updated` to inspect the individual bulk or daily datasets.


### PR DESCRIPTION
## Summary
- stop resetting and force-pushing the previous daily update commit
- publish each validated midnight CSV as a normal commit on `main`
- replace the README force-pull note with a one-time hard reset, then `git pull`
- point the Python install path at uv instead of Poetry

Git object growth (throwaway packed clone, not committed): the updates CSV is 48,006,142 working-tree bytes (~45.8 MiB). Appending one UTC day (~1,440 rows) adds 70,560 bytes. After packing three successive snapshots, extra daily versions stored as ~1.3 KiB packed deltas against the current blob (~13.6 MiB packed). That is safe for GitHub.

Last rewritten daily commit (history anchor): `e8c1239` (`:package: Daily update: 2026-08-28`). Later tooling commits already sit on top of it. After this change, the next 00:00 UTC job should be the first append-only daily commit.

## Test plan
- [x] 26 validator tests passed on Python 3.14.7
- [x] real updates file and historical seam validated
- [x] actionlint and ShellCheck passed for the edited workflow
- [x] published data files unchanged


Made with [Cursor](https://cursor.com)