### PR TITLE
:package: Rebuild historical dataset with correct UTC timestamps

### DIFF
--- a/.github/workflows/validate-dataset.yml
+++ b/.github/workflows/validate-dataset.yml
@@ -34,8 +34,12 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
-      - name: Validate historical tail and updates seam
+      - name: Validate historical dataset and updates seam
         run: |
           uv run python scripts/validate_dataset.py \
-            --historical-tail tests/fixtures/historical_tail.csv \
-            --updates data/updates/btcusd_bitstamp_1min_latest.csv
+            --historical-tail data/historical/btcusd_bitstamp_1min_2012-2025.csv.gz \
+            --updates data/updates/btcusd_bitstamp_1min_latest.csv \
+            --expected-first 1325376060 \
+            --expected-last 1736208000 \
+            --expected-rows 6847200 \
+            --expected-sha256 1be152060b39327b669cbed236eeb283191fadaf3862f76c1e974be54ceb1a20

--- a/README.md
+++ b/README.md
@@ -12,21 +12,35 @@ The historical dataset is saved in [data/historical/btcusd_bitstamp_1min_2012-20
 Some facts about the data:
 
 - **Date Range:** From 1 January 2012 to 7 January 2025.
-- **Number of Records:** 6,846,600
-- **File Size:** Approximately 90MB zipped, 326MB unzipped.
-- **Data Integrity:** No missing minutes, no duplicates, and no null values.
+- **Number of Records:** 6,847,200
+- **File Size:** Approximately 89MB zipped, 327MB unzipped.
+- **Data Integrity:** Complete 60-second grid, with no duplicate timestamps or null values.
 
 ### Data Preview
 
 Below is a preview of the first and last two rows of the bulk dataset:
 
-| timestamp  | open     | high     | low      | close    | volume   |
-| ---------- | -------- | -------- | -------- | -------- | -------- |
-| 1325412060 | 4.58     | 4.58     | 4.58     | 4.58     | 0.0      |
-| 1325412120 | 4.58     | 4.58     | 4.58     | 4.58     | 0.0      |
-| ...        | ...      | ...      | ...      | ...      | ...      |
-| 1736207940 | 102280.0 | 102280.0 | 102280.0 | 102280.0 | 0.007554 |
-| 1736208000 | 102278.0 | 102291.0 | 102263.0 | 102263.0 | 0.523107 |
+| timestamp  | open     | high     | low      | close    | volume     |
+| ---------- | -------- | -------- | -------- | -------- | ---------- |
+| 1325376060 | 4.58     | 4.58     | 4.58     | 4.58     | 0.0        |
+| 1325376120 | 4.58     | 4.58     | 4.58     | 4.58     | 0.0        |
+| ...        | ...      | ...      | ...      | ...      | ...        |
+| 1736207940 | 102280.0 | 102280.0 | 102280.0 | 102280.0 | 0.00755403 |
+| 1736208000 | 102278.0 | 102291.0 | 102263.0 | 102263.0 | 0.52310682 |
+
+> Note: We interpret `timestamp` as the open time of the interval in UTC, so
+> each row corresponds to `[timestamp, timestamp + 60s)`. This is backed by
+> Bitstamp trade and candle comparisons, but is not an official Bitstamp
+> guarantee.
+
+The historical file comes from version 706 of
+[Bitcoin Historical Data](https://www.kaggle.com/datasets/mczielinski/bitcoin-historical-data)
+by Zielak (mczielinski), licensed under
+[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). Earlier copies
+of this repository had incorrect UTC timestamps before 08:01 UTC on
+13 September 2024; those rows have now been corrected. The MIT license in this
+repository applies to the code, while the historical data keeps its source
+license.
 
 ## Daily Updates
 
@@ -71,8 +85,8 @@ the repository root:
 uv sync
 ```
 
-We have a [sample script](scripts/inspect_data.py) for you to inspect the data integrity
-(validate that there are no missing minutes, no duplicates, no nulls, etc):
+We have a [sample script](scripts/inspect_data.py) for checking the timestamp
+range, duplicate timestamps, null values, and summary statistics:
 
 ```bash
 uv run python -m scripts.inspect_data merged
@@ -106,9 +120,9 @@ df.info()
 
 > Forked from [mczielinski/kaggle-bitcoin](https://github.com/mczielinski/kaggle-bitcoin) and fixed some issues.
 
-See [scripts/README.md](scripts/README.md) for more information on how this data was onboarded.
+See [scripts/README.md](scripts/README.md) for more information on how the historical dataset was onboarded.
 
-Go to [scripts/update_data.py](scripts/update_data.py) and
+Daily updates are fetched from the Bitstamp API. Go to [scripts/update_data.py](scripts/update_data.py) and
 [.github/workflows/update-automation.yml](.github/workflows/update-automation.yml)
 if you are curious about how the data is processed and kept up-to-date.
 

--- a/data/original/source-manifest.json
+++ b/data/original/source-manifest.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "canonical_source": "kaggle",
+  "kaggle": {
+    "dataset": "mczielinski/bitcoin-historical-data",
+    "version": 706,
+    "download_url": "https://www.kaggle.com/api/v1/datasets/download/mczielinski/bitcoin-historical-data?datasetVersionNumber=706",
+    "license": "CC BY-SA 4.0",
+    "license_url": "https://creativecommons.org/licenses/by-sa/4.0/",
+    "attribution": "Zielak (mczielinski), Bitcoin Historical Data, Kaggle",
+    "acquired_at": "2026-08-29T12:19:00Z",
+    "kaggle_last_updated": "2026-08-29T04:49:44.907Z",
+    "filename": "btcusd_1-min_data.csv",
+    "sha256": "c3ea6522e69673da38baf88755644d546363e8a96ac60f9e7dafe003c890817f",
+    "header": ["Timestamp", "Open", "High", "Low", "Close", "Volume"],
+    "row_count": 7710039,
+    "first_timestamp": 1325376060,
+    "last_timestamp": 1787978340
+  },
+  "publication": {
+    "path": "data/historical/btcusd_bitstamp_1min_2012-2025.csv.gz",
+    "sha256": "1be152060b39327b669cbed236eeb283191fadaf3862f76c1e974be54ceb1a20",
+    "first_timestamp": 1325376060,
+    "last_timestamp": 1736208000,
+    "row_count": 6847200,
+    "columns": ["timestamp", "open", "high", "low", "close", "volume"]
+  },
+  "legacy_community_gaps": {
+    "status": "audit_only",
+    "filename": "missing_ohlc_data_all_gaps_as_of_1736148000.csv",
+    "source_url": "https://github.com/mczielinski/kaggle-bitcoin/issues/2#issuecomment-2577927918",
+    "sha256": "1b529fbb68633a16c1c1feebbb00ced0656ad2a37fbf7eda0a26391fd7c2a752",
+    "row_count": 106320,
+    "notes": "Exact subset of Kaggle v706; not used when building the published historical file."
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,50 +2,95 @@
 
 ## Original Data
 
-We download the original data from Kaggle:
-<https://www.kaggle.com/datasets/mczielinski/bitcoin-historical-data?resource=download&select=btcusd_1-min_data.csv>
+We use version 706 of the original Kaggle dataset:
+<https://www.kaggle.com/datasets/mczielinski/bitcoin-historical-data>
 
-Save this in `data/original/btcusd_1-min_data.csv`.
+Save this in `data/original/btcusd_1-min_data.csv`:
 
-> NB: At time of writing, there is a spurious false record in the very last row of the dataset.
-> Manually delete this, or use `sed -i '$ d' btcusd_1-min_data.csv` to remove it.
+```sh
+mkdir -p data/original
+curl -L "https://www.kaggle.com/api/v1/datasets/download/mczielinski/bitcoin-historical-data?datasetVersionNumber=706" \
+  | funzip > data/original/btcusd_1-min_data.csv
+```
+
+Check that you have the same file:
+
+```sh
+sha256sum data/original/btcusd_1-min_data.csv
+# expected: c3ea6522e69673da38baf88755644d546363e8a96ac60f9e7dafe003c890817f
+```
+
+We pin the version and checksum because a newer Kaggle version may contain
+different data. The full details are saved in
+[data/original/source-manifest.json](../data/original/source-manifest.json).
 
 ## Missing Data
 
-The original dataset has missing data, and a collection of gaps has graciously been shared:
+Older versions of the Kaggle file had gaps. A collection of those missing rows
+was shared here:
 <https://github.com/mczielinski/kaggle-bitcoin/issues/2#issuecomment-2577927918>
 
-Extract and save this in `data/original/missing_ohlc_data_all_gaps_as_of_1736148000.csv`.
+Version 706 already contains every row from that file, so it is no longer
+merged into the historical dataset.
 
-## Processing the Merged, Bulk Data
+## Checking the Source
 
-1. Follow the above download and save steps
-2. Run `python scripts/preprocess_bulk_data.py` to merge the gap data into the bulk data
+This checks the downloaded file and compares a small selection of candles with
+the Bitstamp API:
 
-The script will print out the missing timestamps (known issue), and truncate the data up to the first missing timestamp.
+```bash
+uv run python scripts/verify_source.py
+```
 
-Data integrity is validated (no duplicate timestamps, no missing values),
-and finally saved in `data/historical/btcusd_bitstamp_1min_2012-2025.csv`
+The comparison covers the DST changes from 2012 through 2024, the old
+timestamp boundary, and a few known gaps and outages. It does not download the
+full history from Bitstamp.
+
+## Processing the Bulk Data
+
+```bash
+uv run python scripts/preprocess_bulk_data.py
+```
+
+The script reads the Kaggle file one row at a time and copies the data through
+`2025-01-07 00:00 UTC`. It changes the column names to lowercase, but does not
+shift timestamps, merge the old gap file, or fill any rows.
+
+The result is saved directly in:
+`data/historical/btcusd_bitstamp_1min_2012-2025.csv.gz`
 
 ## After Processing
 
-Inspect the data using `python scripts/inspect_data.py`.
+Check the result and its connection to the daily updates:
 
-Zip before uploading to github:
+```sh
+uv run python scripts/validate_dataset.py \
+  --historical-tail data/historical/btcusd_bitstamp_1min_2012-2025.csv.gz \
+  --updates data/updates/btcusd_bitstamp_1min_latest.csv \
+  --expected-first 1325376060 \
+  --expected-last 1736208000 \
+  --expected-rows 6847200 \
+  --expected-sha256 1be152060b39327b669cbed236eeb283191fadaf3862f76c1e974be54ceb1a20
+```
+
+You can inspect it in more detail with:
 
 ```bash
-gzip -k data/historical/btcusd_bitstamp_1min_2012-2025.csv
+uv run python scripts/inspect_data.py bulk
 ```
 
 Now you're ready to run the update script:
 
 ```bash
-python scripts/update_data.py
+uv run python scripts/update_data.py
 ```
 
-This will save Bitstamp data since the bulk, historical dataset was last updated in a separate file,
-located in `data/updates/btcusd_bitstamp_1min_latest.csv`.
+This saves Bitstamp data since the bulk historical dataset was last updated in
+a separate file at `data/updates/btcusd_bitstamp_1min_latest.csv`.
+If Bitstamp leaves out a minute, the current update script keeps the grid
+complete with a flat candle at the previous close and zero volume.
 
 ## Want to Know More?
 
-See [.github/workflows/update-automation.yml](../.github/workflows/update-automation.yml) for how the data is kept up-to-date.
+See [.github/workflows/update-automation.yml](../.github/workflows/update-automation.yml)
+for how the data is kept up to date.

--- a/scripts/historical_source.py
+++ b/scripts/historical_source.py
@@ -1,0 +1,381 @@
+"""Pinned Kaggle source contract and streaming historical bulk builder."""
+
+import csv
+import gzip
+import hashlib
+import io
+import json
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+MINUTE_SECONDS = 60
+PUBLIC_HEADER = ("timestamp", "open", "high", "low", "close", "volume")
+KAGGLE_HEADER = ("Timestamp", "Open", "High", "Low", "Close", "Volume")
+HASH_CHUNK_SIZE = 1024 * 1024
+GZIP_COMPRESSLEVEL = 9
+GZIP_MTIME = 0
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST_PATH = REPO_ROOT / "data" / "original" / "source-manifest.json"
+DEFAULT_SOURCE_CSV = REPO_ROOT / "data" / "original" / "btcusd_1-min_data.csv"
+DEFAULT_OUTPUT_PATH = (
+    REPO_ROOT / "data" / "historical" / "btcusd_bitstamp_1min_2012-2025.csv.gz"
+)
+
+
+class SourceError(ValueError):
+    """Pinned source or publication slice is not acceptable."""
+
+
+@dataclass(frozen=True)
+class PublicationSpec:
+    source_path: Path
+    sha256: str
+    header: tuple[str, ...]
+    source_first_timestamp: int
+    source_last_timestamp: int
+    source_expected_rows: int
+    first_timestamp: int
+    last_timestamp: int
+    expected_rows: int
+    output_sha256: str | None = None
+
+
+def load_manifest(path: Path | None = None) -> dict:
+    manifest_path = path or DEFAULT_MANIFEST_PATH
+    with manifest_path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def publication_spec_from_manifest(
+    manifest: dict,
+    *,
+    source_path: Path | None = None,
+) -> PublicationSpec:
+    kaggle = manifest["kaggle"]
+    publication = manifest["publication"]
+    spec = PublicationSpec(
+        source_path=source_path or DEFAULT_SOURCE_CSV,
+        sha256=str(kaggle["sha256"]),
+        header=tuple(kaggle["header"]),
+        source_first_timestamp=int(kaggle["first_timestamp"]),
+        source_last_timestamp=int(kaggle["last_timestamp"]),
+        source_expected_rows=int(kaggle["row_count"]),
+        first_timestamp=int(publication["first_timestamp"]),
+        last_timestamp=int(publication["last_timestamp"]),
+        expected_rows=int(publication["row_count"]),
+        output_sha256=(str(publication["sha256"]) if "sha256" in publication else None),
+    )
+    if spec.header != KAGGLE_HEADER:
+        raise SourceError(
+            f"manifest source header must be {list(KAGGLE_HEADER)!r}, "
+            f"found {list(spec.header)!r}"
+        )
+    if tuple(publication["columns"]) != PUBLIC_HEADER:
+        raise SourceError(
+            f"manifest publication columns must be {list(PUBLIC_HEADER)!r}"
+        )
+    _validate_extent(
+        "source",
+        spec.source_first_timestamp,
+        spec.source_last_timestamp,
+        spec.source_expected_rows,
+    )
+    _validate_extent(
+        "publication",
+        spec.first_timestamp,
+        spec.last_timestamp,
+        spec.expected_rows,
+    )
+    if spec.first_timestamp != spec.source_first_timestamp:
+        raise SourceError("publication must start at the first source timestamp")
+    if spec.last_timestamp > spec.source_last_timestamp:
+        raise SourceError("publication must end within the source range")
+    return spec
+
+
+def _validate_extent(name: str, first: int, last: int, rows: int) -> None:
+    if first % MINUTE_SECONDS or last % MINUTE_SECONDS or last < first:
+        raise SourceError(f"invalid {name} timestamp range {first}..{last}")
+    expected_rows = (last - first) // MINUTE_SECONDS + 1
+    if rows != expected_rows:
+        raise SourceError(
+            f"{name} row count {rows} does not match its timestamp range "
+            f"({expected_rows})"
+        )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(HASH_CHUNK_SIZE)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_sha256(path: Path, expected: str) -> str:
+    actual = sha256_file(path)
+    if actual != expected:
+        raise SourceError(
+            f"SHA-256 mismatch for {path}: expected {expected}, found {actual}"
+        )
+    return actual
+
+
+def _parse_minute_timestamp(raw: str, *, row_number: int) -> int:
+    if raw != raw.strip() or not raw.isdigit():
+        raise SourceError(
+            f"row {row_number}: timestamp must be an unsigned base-10 integer, "
+            f"found {raw!r}"
+        )
+    timestamp = int(raw)
+    if timestamp % MINUTE_SECONDS != 0:
+        raise SourceError(
+            f"row {row_number}: timestamp {timestamp} is not minute-aligned"
+        )
+    return timestamp
+
+
+def _validate_ohlcv(row: Sequence[str], *, row_number: int) -> None:
+    try:
+        open_price, high_price, low_price, close_price, volume = (
+            Decimal(value) for value in row[1:]
+        )
+    except (InvalidOperation, ValueError) as exc:
+        raise SourceError(f"row {row_number}: invalid OHLCV number") from exc
+
+    values = (open_price, high_price, low_price, close_price, volume)
+    if not all(value.is_finite() for value in values):
+        raise SourceError(f"row {row_number}: OHLCV values must be finite")
+    if min(open_price, high_price, low_price, close_price) <= 0:
+        raise SourceError(f"row {row_number}: OHLC prices must be positive")
+    if volume < 0:
+        raise SourceError(f"row {row_number}: volume must be non-negative")
+    if low_price > min(open_price, close_price):
+        raise SourceError(f"row {row_number}: low is above open or close")
+    if high_price < max(open_price, close_price):
+        raise SourceError(f"row {row_number}: high is below open or close")
+
+
+def verify_source_shape(source_path: Path, spec: PublicationSpec) -> int:
+    """Validate the complete pinned CSV's range and minute continuity."""
+    with source_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, None)
+        if header != list(spec.header):
+            raise SourceError(
+                f"invalid source header: expected {list(spec.header)!r}, "
+                f"found {header!r}"
+            )
+
+        first_timestamp: int | None = None
+        previous_timestamp: int | None = None
+        row_count = 0
+        for row_number, row in enumerate(reader, start=2):
+            if len(row) != len(PUBLIC_HEADER):
+                raise SourceError(
+                    f"row {row_number}: expected {len(PUBLIC_HEADER)} columns, "
+                    f"found {len(row)}"
+                )
+            if any(field.strip() == "" for field in row):
+                raise SourceError(f"row {row_number}: empty field")
+            timestamp = _parse_minute_timestamp(row[0], row_number=row_number)
+            if previous_timestamp is None:
+                first_timestamp = timestamp
+            elif timestamp != previous_timestamp + MINUTE_SECONDS:
+                raise SourceError(
+                    f"row {row_number}: expected timestamp "
+                    f"{previous_timestamp + MINUTE_SECONDS}, found {timestamp}"
+                )
+            previous_timestamp = timestamp
+            row_count += 1
+
+    if first_timestamp != spec.source_first_timestamp:
+        raise SourceError(
+            f"expected source first timestamp {spec.source_first_timestamp}, "
+            f"found {first_timestamp}"
+        )
+    if previous_timestamp != spec.source_last_timestamp:
+        raise SourceError(
+            f"expected source last timestamp {spec.source_last_timestamp}, "
+            f"found {previous_timestamp}"
+        )
+    if row_count != spec.source_expected_rows:
+        raise SourceError(
+            f"expected {spec.source_expected_rows} source rows, found {row_count}"
+        )
+    return row_count
+
+
+def iter_publication_rows(
+    source_path: Path,
+    spec: PublicationSpec,
+) -> Iterator[list[str]]:
+    """Yield public six-column rows for the pinned publication slice."""
+    with source_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = next(reader)
+        except StopIteration as exc:
+            raise SourceError(f"{source_path} is empty") from exc
+
+        if header != list(spec.header):
+            raise SourceError(
+                f"invalid source header: expected {list(spec.header)!r}, "
+                f"found {header!r}"
+            )
+
+        previous_timestamp: int | None = None
+        emitted = 0
+        reached_end = False
+
+        for row_number, row in enumerate(reader, start=2):
+            if reached_end:
+                break
+            if len(row) != len(PUBLIC_HEADER):
+                raise SourceError(
+                    f"row {row_number}: expected {len(PUBLIC_HEADER)} columns, "
+                    f"found {len(row)}"
+                )
+            timestamp = _parse_minute_timestamp(row[0], row_number=row_number)
+            if any(field.strip() == "" for field in row):
+                raise SourceError(f"row {row_number}: empty field")
+            _validate_ohlcv(row, row_number=row_number)
+
+            if timestamp < spec.first_timestamp:
+                raise SourceError(
+                    f"row {row_number}: timestamp {timestamp} precedes "
+                    f"publication start {spec.first_timestamp}"
+                )
+            if timestamp > spec.last_timestamp:
+                raise SourceError(
+                    "publication slice ended before last_timestamp "
+                    f"{spec.last_timestamp} (next source timestamp {timestamp})"
+                )
+
+            if previous_timestamp is None:
+                if timestamp != spec.first_timestamp:
+                    raise SourceError(
+                        f"row {row_number}: expected first timestamp "
+                        f"{spec.first_timestamp}, found {timestamp}"
+                    )
+            elif timestamp == previous_timestamp:
+                raise SourceError(f"row {row_number}: duplicate timestamp {timestamp}")
+            elif timestamp != previous_timestamp + MINUTE_SECONDS:
+                raise SourceError(
+                    f"row {row_number}: timestamp gap: expected "
+                    f"{previous_timestamp + MINUTE_SECONDS}, found {timestamp}"
+                )
+
+            yield [row[0], row[1], row[2], row[3], row[4], row[5]]
+            emitted += 1
+            previous_timestamp = timestamp
+            if timestamp == spec.last_timestamp:
+                try:
+                    following = next(reader)
+                except StopIteration:
+                    reached_end = True
+                    break
+                following_number = row_number + 1
+                if len(following) != len(PUBLIC_HEADER):
+                    raise SourceError(
+                        f"row {following_number}: expected {len(PUBLIC_HEADER)} columns, "
+                        f"found {len(following)}"
+                    )
+                following_timestamp = _parse_minute_timestamp(
+                    following[0], row_number=following_number
+                )
+                if following_timestamp == spec.last_timestamp:
+                    raise SourceError(
+                        f"row {following_number}: duplicate timestamp "
+                        f"{following_timestamp}"
+                    )
+                if following_timestamp < spec.last_timestamp:
+                    raise SourceError(
+                        f"row {following_number}: out-of-order timestamp "
+                        f"{following_timestamp}"
+                    )
+                reached_end = True
+                break
+
+    if previous_timestamp is None:
+        raise SourceError(f"{source_path} contains no data rows")
+    if previous_timestamp != spec.last_timestamp:
+        raise SourceError(
+            f"source ended at {previous_timestamp}, expected publication "
+            f"last_timestamp {spec.last_timestamp}"
+        )
+    if emitted != spec.expected_rows:
+        raise SourceError(
+            f"expected {spec.expected_rows} publication rows, emitted {emitted}"
+        )
+
+
+def write_historical_gzip(
+    rows: Iterable[Sequence[str]],
+    output_path: Path,
+    *,
+    compresslevel: int = GZIP_COMPRESSLEVEL,
+) -> int:
+    """Write public CSV rows to a deterministic gzip file."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_name(output_path.name + ".tmp")
+    count = 0
+    try:
+        with (
+            tmp_path.open("wb") as raw,
+            gzip.GzipFile(
+                filename="",
+                mode="wb",
+                fileobj=raw,
+                mtime=GZIP_MTIME,
+                compresslevel=compresslevel,
+            ) as gz,
+            io.TextIOWrapper(
+                gz, encoding="utf-8", newline="", write_through=True
+            ) as text,
+        ):
+            writer = csv.writer(text, lineterminator="\n")
+            writer.writerow(PUBLIC_HEADER)
+            for row in rows:
+                writer.writerow(row)
+                count += 1
+        tmp_path.replace(output_path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+    return count
+
+
+def build_historical_dataset(
+    spec: PublicationSpec,
+    output_path: Path,
+    *,
+    verify_hash: bool = True,
+) -> int:
+    """Verify the pinned source and write the publication gzip."""
+    if not spec.source_path.is_file():
+        raise SourceError(f"source CSV not found: {spec.source_path}")
+    if verify_hash:
+        verify_sha256(spec.source_path, spec.sha256)
+    verify_source_shape(spec.source_path, spec)
+
+    candidate_path = output_path.with_name(output_path.name + ".candidate")
+    try:
+        row_count = write_historical_gzip(
+            iter_publication_rows(spec.source_path, spec), candidate_path
+        )
+        if spec.output_sha256 is not None:
+            verify_sha256(candidate_path, spec.output_sha256)
+        candidate_path.replace(output_path)
+    except Exception:
+        if candidate_path.exists():
+            candidate_path.unlink()
+        raise
+    return row_count

--- a/scripts/preprocess_bulk_data.py
+++ b/scripts/preprocess_bulk_data.py
@@ -1,182 +1,72 @@
-import os
+"""Build the published historical gzip from the pinned Kaggle snapshot."""
+
+import argparse
 import sys
+from pathlib import Path
 
-import pandas as pd
+from scripts.historical_source import (
+    DEFAULT_OUTPUT_PATH,
+    DEFAULT_SOURCE_CSV,
+    SourceError,
+    build_historical_dataset,
+    load_manifest,
+    publication_spec_from_manifest,
+)
 
 
-def load_original_data(
-    bulk_data_path: str, missing_data_path: str
-) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Load the original and missing datasets."""
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Stream the pinned Kaggle BTC/USD snapshot into the published "
+            "historical gzip. No community merge, timezone shift, or fill."
+        )
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Path to source-manifest.json (default: data/original/source-manifest.json).",
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="Path to the pinned Kaggle CSV (default: data/original/btcusd_1-min_data.csv).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Path to write the historical gzip.",
+    )
+    parser.add_argument(
+        "--skip-hash",
+        action="store_true",
+        help="Skip SHA-256 verification (tests only).",
+    )
+    args = parser.parse_args(argv)
+
     try:
-        bulk_df = pd.read_csv(bulk_data_path)
-        print(f"Loaded bulk data with {len(bulk_df)} records.")
-    except Exception as e:  # noqa: BLE001
-        print(f"Error loading bulk data: {e}")
-        sys.exit(1)
+        manifest = load_manifest(args.manifest)
+        spec = publication_spec_from_manifest(
+            manifest,
+            source_path=args.source or DEFAULT_SOURCE_CSV,
+        )
+        row_count = build_historical_dataset(
+            spec,
+            args.output,
+            verify_hash=not args.skip_hash,
+        )
+    except (OSError, SourceError, KeyError, TypeError, ValueError) as exc:
+        print(f"Error building historical dataset: {exc}", file=sys.stderr)
+        return 1
 
-    try:
-        missing_df = pd.read_csv(missing_data_path)
-        print(f"Loaded missing data with {len(missing_df)} records.")
-    except Exception as e:  # noqa: BLE001
-        print(f"Error loading missing data: {e}")
-        sys.exit(1)
-
-    return bulk_df, missing_df
-
-
-def standardize_bulk_data(df: pd.DataFrame) -> pd.DataFrame:
-    """Standardize the bulk dataset columns."""
-    df = df.rename(
-        columns={
-            "Timestamp": "timestamp",
-            "Open": "open",
-            "High": "high",
-            "Low": "low",
-            "Close": "close",
-            "Volume": "volume",
-        }
+    print(
+        f"Wrote {row_count} rows to {args.output} "
+        f"({spec.first_timestamp}..{spec.last_timestamp})."
     )
-    return df[["timestamp", "open", "high", "low", "close", "volume"]]
-
-
-def standardize_missing_data(df: pd.DataFrame) -> pd.DataFrame:
-    """Standardize the missing dataset columns."""
-    df = df.rename(
-        columns={
-            "timestamp_unix": "timestamp",
-            "open": "open",
-            "high": "high",
-            "low": "low",
-            "close": "close",
-            "volume": "volume",
-        }
-    )
-    return df[["timestamp", "open", "high", "low", "close", "volume"]]
-
-
-def merge_datasets(bulk_df: pd.DataFrame, missing_df: pd.DataFrame) -> pd.DataFrame:
-    """Merge the bulk and missing datasets."""
-    merged_df = pd.concat([bulk_df, missing_df], ignore_index=True)
-    merged_df.drop_duplicates(subset="timestamp", inplace=True)
-    merged_df.sort_values(by="timestamp", inplace=True)
-    merged_df.reset_index(drop=True, inplace=True)
-    return merged_df
-
-
-def check_missing_timestamps(df: pd.DataFrame, interval_seconds: int = 60) -> list[int]:
-    """Check for missing timestamps in the merged dataset."""
-    df = df.sort_values(by="timestamp").reset_index(drop=True)
-
-    # Convert timestamps to integers
-    start = int(df["timestamp"].iloc[0])
-    end = int(df["timestamp"].iloc[-1] + interval_seconds)
-
-    expected_timestamps = list(range(start, end, interval_seconds))
-    actual_timestamps = df["timestamp"].astype(int).tolist()
-    missing = sorted(set(expected_timestamps) - set(actual_timestamps))
-
-    if missing:
-        print(f"Missing {len(missing)} timestamps.")
-        # Optionally, print missing timestamps
-        # Group consecutive timestamps into ranges
-        ranges = []
-        range_start = missing[0]
-        prev = missing[0]
-
-        for ts in missing[1:]:
-            if ts - prev > interval_seconds:
-                ranges.append((range_start, prev))
-                range_start = ts
-            prev = ts
-        ranges.append((range_start, prev))
-
-        # Print the ranges
-        for start, end in ranges:
-            print(
-                f"Gap from {start} to {end} ({(end - start) // interval_seconds} minutes)"
-            )
-    else:
-        print("No missing timestamps found.")
-    return missing
-
-
-def validate_data(df: pd.DataFrame) -> None:
-    """Validate data integrity."""
-    # Check for duplicates
-    duplicates = df.duplicated(subset="timestamp").sum()
-    if duplicates > 0:
-        print(f"Data contains {duplicates} duplicate timestamps.")
-    else:
-        print("No duplicate timestamps found.")
-
-    # Check for NaN values
-    nan_values = df.isnull().sum().sum()
-    if nan_values > 0:
-        print(f"Data contains {nan_values} missing values.")
-    else:
-        print("No missing values found in data.")
-
-    # Additional validations can be added here
-
-
-def save_merged_data(df: pd.DataFrame, output_path: str) -> None:
-    """Save the merged dataset to the specified path."""
-    try:
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        df.to_csv(output_path, index=False)
-        print(f"Merged data saved to {output_path}.")
-    except Exception as e:  # noqa: BLE001
-        print(f"Error saving merged data: {e}")
-        sys.exit(1)
-
-
-def main() -> None:
-    # Define file paths
-    bulk_data_path = os.path.join("data", "original", "btcusd_1-min_data.csv")
-    missing_data_path = os.path.join(
-        "data", "original", "missing_ohlc_data_all_gaps_as_of_1736148000.csv"
-    )
-    output_path = os.path.join(
-        "data", "historical", "btcusd_bitstamp_1min_2012-2025.csv"
-    )
-
-    # Ensure output directory exists
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-
-    # Load data
-    bulk_df, missing_df = load_original_data(bulk_data_path, missing_data_path)
-
-    # Standardize datasets
-    bulk_df = standardize_bulk_data(bulk_df)
-    missing_df = standardize_missing_data(missing_df)
-
-    # Merge datasets
-    merged_df = merge_datasets(bulk_df, missing_df)
-
-    # Check for missing timestamps
-    missing_timestamps = check_missing_timestamps(merged_df)
-
-    if missing_timestamps:
-        # Truncate data up to the first missing timestamp
-        first_missing = missing_timestamps[0]
-        merged_df = merged_df[merged_df["timestamp"] < first_missing]
-        print(f"Truncated data up to first missing timestamp: {first_missing}")
-
-    # Set timestamp column to integer type
-    merged_df["timestamp"] = merged_df["timestamp"].astype(int)
-
-    # Validate data integrity
-    validate_data(merged_df)
-
-    # Save merged data
-    save_merged_data(merged_df, output_path)
-
-    if missing_timestamps:
-        print("Data preprocessing completed with truncation due to missing timestamps.")
-    else:
-        print("Data preprocessing completed successfully.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/validate_dataset.py
+++ b/scripts/validate_dataset.py
@@ -1,10 +1,9 @@
 """Streaming validator for Bitstamp BTC/USD one-minute OHLC CSV datasets."""
 
-from __future__ import annotations
-
 import argparse
 import csv
 import gzip
+import hashlib
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -16,6 +15,7 @@ EXPECTED_HEADER = "timestamp,open,high,low,close,volume"
 COLUMN_NAMES = ("timestamp", "open", "high", "low", "close", "volume")
 MAX_ISSUES = 20
 MINUTE_SECONDS = 60
+HASH_CHUNK_SIZE = 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -306,6 +306,60 @@ def validate_dataset(path: str | Path) -> ValidationResult:
     return result
 
 
+def expected_summary_issues(
+    summary: DatasetSummary,
+    *,
+    expected_first: int | None = None,
+    expected_last: int | None = None,
+    expected_rows: int | None = None,
+) -> tuple[ValidationIssue, ...]:
+    """Check a validated summary against pinned publication extents."""
+    issues: list[ValidationIssue] = []
+    if expected_rows is not None and summary.row_count != expected_rows:
+        _add_issue(
+            issues,
+            row_number=None,
+            message=(
+                f"expected {expected_rows} historical rows, found {summary.row_count}"
+            ),
+        )
+    if expected_first is not None and summary.first_timestamp != expected_first:
+        _add_issue(
+            issues,
+            row_number=None,
+            message=(
+                f"expected first timestamp {expected_first}, "
+                f"found {summary.first_timestamp}"
+            ),
+        )
+    if expected_last is not None and summary.last_timestamp != expected_last:
+        _add_issue(
+            issues,
+            row_number=None,
+            message=(
+                f"expected last timestamp {expected_last}, "
+                f"found {summary.last_timestamp}"
+            ),
+        )
+    return tuple(issues)
+
+
+def validate_sha256(path: str | Path, expected: str) -> ValidationIssue | None:
+    """Return an issue when a file does not match its pinned SHA-256."""
+    digest = hashlib.sha256()
+    try:
+        with Path(path).open("rb") as handle:
+            while chunk := handle.read(HASH_CHUNK_SIZE):
+                digest.update(chunk)
+    except OSError as exc:
+        return ValidationIssue(f"cannot hash file: {exc}")
+
+    actual = digest.hexdigest()
+    if actual != expected:
+        return ValidationIssue(f"SHA-256 mismatch: expected {expected}, found {actual}")
+    return None
+
+
 def validate_seam(
     historical: DatasetSummary,
     updates: DatasetSummary,
@@ -382,11 +436,45 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         help="Path to the updates CSV.",
     )
+    parser.add_argument(
+        "--expected-first",
+        type=int,
+        default=None,
+        help="Expected first historical timestamp (Unix seconds).",
+    )
+    parser.add_argument(
+        "--expected-last",
+        type=int,
+        default=None,
+        help="Expected last historical timestamp (Unix seconds).",
+    )
+    parser.add_argument(
+        "--expected-rows",
+        type=int,
+        default=None,
+        help="Expected historical row count.",
+    )
+    parser.add_argument(
+        "--expected-sha256",
+        default=None,
+        help="Expected SHA-256 of the historical file.",
+    )
     args = parser.parse_args(argv)
 
     historical_result, updates_result, seam_issues = validate_historical_and_updates(
         args.historical_tail,
         args.updates,
+    )
+    expected_issues = expected_summary_issues(
+        historical_result.summary,
+        expected_first=args.expected_first,
+        expected_last=args.expected_last,
+        expected_rows=args.expected_rows,
+    )
+    checksum_issue = (
+        validate_sha256(args.historical_tail, args.expected_sha256)
+        if args.expected_sha256 is not None
+        else None
     )
 
     exit_code = 0
@@ -410,6 +498,17 @@ def main(argv: list[str] | None = None) -> int:
         print("seam validation failed:", file=sys.stderr)
         for issue in seam_issues:
             print(f"  {format_issue(issue)}", file=sys.stderr)
+
+    if expected_issues:
+        exit_code = 1
+        print("historical summary mismatch:", file=sys.stderr)
+        for issue in expected_issues:
+            print(f"  {format_issue(issue)}", file=sys.stderr)
+
+    if checksum_issue is not None:
+        exit_code = 1
+        print("historical checksum mismatch:", file=sys.stderr)
+        print(f"  {format_issue(checksum_issue)}", file=sys.stderr)
 
     if exit_code == 0:
         print(format_summary(historical_result.summary))

--- a/scripts/verify_source.py
+++ b/scripts/verify_source.py
@@ -1,0 +1,403 @@
+"""Bounded Bitstamp and local-lineage checks for the pinned Kaggle snapshot."""
+
+import argparse
+import calendar
+import csv
+import sys
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+import requests
+
+from scripts.historical_source import (
+    DEFAULT_SOURCE_CSV,
+    KAGGLE_HEADER,
+    MINUTE_SECONDS,
+    SourceError,
+    iter_publication_rows,
+    load_manifest,
+    publication_spec_from_manifest,
+    verify_sha256,
+    verify_source_shape,
+)
+
+BITSTAMP_OHLC_URL = "https://www.bitstamp.net/api/v2/ohlc/btcusd/"
+MAX_API_REQUESTS = 40
+API_LIMIT = 1000
+API_SLEEP_SECONDS = 0.2
+
+
+@dataclass(frozen=True)
+class Window:
+    name: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    window: str
+    timestamp: int
+    detail: str
+
+
+class RequestBudget:
+    def __init__(self, maximum: int = MAX_API_REQUESTS) -> None:
+        self.maximum = maximum
+        self.used = 0
+
+    def consume(self) -> None:
+        if self.used >= self.maximum:
+            raise SourceError(f"API request budget exceeded ({self.maximum} requests)")
+        self.used += 1
+
+
+def _unix(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> int:
+    return int(datetime(year, month, day, hour, minute, tzinfo=UTC).timestamp())
+
+
+def _nth_sunday(year: int, month: int, n: int) -> int:
+    sundays = [
+        day
+        for day in calendar.Calendar().itermonthdays(year, month)
+        if day and date(year, month, day).weekday() == calendar.SUNDAY
+    ]
+    return sundays[n - 1]
+
+
+def _dst_window(year: int, month: int, n: int, name: str) -> Window:
+    day = _nth_sunday(year, month, n)
+    start = _unix(year, month, day, 5)
+    end = _unix(year, month, day, 8, 59)
+    return Window(name=name, start=start, end=end)
+
+
+def verification_windows() -> tuple[Window, ...]:
+    windows = [
+        Window("early-2012", _unix(2012, 1, 1, 0, 1), _unix(2012, 1, 1, 10, 1)),
+        Window("winter-2013", _unix(2013, 1, 15, 12), _unix(2013, 1, 15, 13, 59)),
+        Window("summer-2013", _unix(2013, 7, 15, 12), _unix(2013, 7, 15, 13, 59)),
+        Window("outage-2020-04", _unix(2020, 4, 7, 19), _unix(2020, 4, 8, 1)),
+        Window("gap-2024-06-01", _unix(2024, 6, 1, 0, 40), _unix(2024, 6, 1, 8)),
+        Window(
+            "boundary-2024-09-13", _unix(2024, 9, 13, 6), _unix(2024, 9, 13, 10, 59)
+        ),
+        Window("seam-2025-01-07", _unix(2025, 1, 6, 23), _unix(2025, 1, 7, 1)),
+    ]
+    for year in range(2012, 2025):
+        windows.append(_dst_window(year, 3, 2, f"spring-dst-{year}"))
+        windows.append(_dst_window(year, 11, 1, f"fall-dst-{year}"))
+    return tuple(windows)
+
+
+def needed_timestamps(windows: Iterable[Window]) -> set[int]:
+    needed: set[int] = set()
+    for window in windows:
+        needed.update(range(window.start, window.end + MINUTE_SECONDS, MINUTE_SECONDS))
+    return needed
+
+
+def _as_decimals(values: Iterable[str]) -> tuple[Decimal, ...]:
+    return tuple(Decimal(value) for value in values)
+
+
+def collect_source_rows(
+    source_path: Path,
+    timestamps: set[int],
+) -> dict[int, list[str]]:
+    found: dict[int, list[str]] = {}
+    with source_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, None)
+        if header != list(KAGGLE_HEADER):
+            raise SourceError(
+                f"unexpected Kaggle header: expected {list(KAGGLE_HEADER)!r}, "
+                f"found {header!r}"
+            )
+        for row_number, row in enumerate(reader, start=2):
+            if len(row) != 6:
+                raise SourceError(f"row {row_number}: expected 6 columns")
+            try:
+                timestamp = int(row[0])
+            except ValueError as exc:
+                raise SourceError(
+                    f"row {row_number}: invalid timestamp {row[0]!r}"
+                ) from exc
+            if timestamp in timestamps:
+                if timestamp in found:
+                    raise SourceError(
+                        f"row {row_number}: duplicate timestamp {timestamp}"
+                    )
+                found[timestamp] = row[:6]
+            if len(found) == len(timestamps) and timestamp >= max(timestamps):
+                break
+    return found
+
+
+def fetch_bitstamp_window(
+    start: int,
+    end: int,
+    budget: RequestBudget,
+    *,
+    session: requests.Session,
+) -> dict[int, list[str]]:
+    rows: dict[int, list[str]] = {}
+    cursor = start
+    while cursor <= end:
+        chunk_end = min(end, cursor + (API_LIMIT - 1) * MINUTE_SECONDS)
+        budget.consume()
+        response = session.get(
+            BITSTAMP_OHLC_URL,
+            params={
+                "step": MINUTE_SECONDS,
+                "start": cursor,
+                "end": chunk_end,
+                "limit": API_LIMIT,
+            },
+            timeout=60,
+        )
+        response.raise_for_status()
+        document = response.json()
+        if not isinstance(document, dict):
+            raise SourceError("Bitstamp response must be a JSON object")
+        data = document.get("data")
+        if not isinstance(data, dict):
+            raise SourceError("Bitstamp response is missing the data object")
+        payload = data.get("ohlc")
+        if not isinstance(payload, list):
+            raise SourceError("Bitstamp response is missing the OHLC list")
+        for item in payload:
+            if not isinstance(item, dict):
+                raise SourceError("Bitstamp OHLC rows must be JSON objects")
+            timestamp = int(item["timestamp"])
+            if start <= timestamp <= end:
+                if timestamp in rows:
+                    raise SourceError(
+                        f"Bitstamp returned duplicate timestamp {timestamp}"
+                    )
+                rows[timestamp] = [
+                    str(item["timestamp"]),
+                    str(item["open"]),
+                    str(item["high"]),
+                    str(item["low"]),
+                    str(item["close"]),
+                    str(item["volume"]),
+                ]
+        cursor = chunk_end + MINUTE_SECONDS
+        if cursor <= end:
+            time.sleep(API_SLEEP_SECONDS)
+    return rows
+
+
+def compare_window(
+    window: Window,
+    source_rows: dict[int, list[str]],
+    api_rows: dict[int, list[str]],
+) -> list[Mismatch]:
+    mismatches: list[Mismatch] = []
+    for timestamp in range(window.start, window.end + MINUTE_SECONDS, MINUTE_SECONDS):
+        source = source_rows.get(timestamp)
+        api = api_rows.get(timestamp)
+        if source is None:
+            mismatches.append(
+                Mismatch(window.name, timestamp, "missing from Kaggle source")
+            )
+            continue
+        if api is None:
+            mismatches.append(
+                Mismatch(window.name, timestamp, "missing from Bitstamp API")
+            )
+            continue
+        try:
+            if _as_decimals(source[1:]) != _as_decimals(api[1:]):
+                mismatches.append(
+                    Mismatch(
+                        window.name,
+                        timestamp,
+                        f"OHLCV mismatch source={source[1:]} api={api[1:]}",
+                    )
+                )
+        except InvalidOperation:
+            mismatches.append(
+                Mismatch(window.name, timestamp, "non-decimal OHLCV value")
+            )
+    return mismatches
+
+
+def verify_community_subset(
+    community_path: Path,
+    source_path: Path,
+) -> tuple[int, int]:
+    community_rows: dict[int, list[str]] = {}
+    with community_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, None)
+        if not header or "timestamp_unix" not in header:
+            raise SourceError(f"unexpected community header: {header!r}")
+        for row_number, row in enumerate(reader, start=2):
+            if len(row) != 8:
+                raise SourceError(
+                    f"community row {row_number}: expected 8 columns, found {len(row)}"
+                )
+            timestamp = int(row[0])
+            if timestamp in community_rows:
+                raise SourceError(
+                    f"community row {row_number}: duplicate timestamp {timestamp}"
+                )
+            community_rows[timestamp] = [
+                row[0],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+            ]
+
+    source_rows = collect_source_rows(source_path, set(community_rows))
+    matched = 0
+    for timestamp, community in community_rows.items():
+        source = source_rows.get(timestamp)
+        if source is None:
+            continue
+        if _as_decimals(source[1:]) == _as_decimals(community[1:]):
+            matched += 1
+    return matched, len(community_rows)
+
+
+def run_verification(
+    *,
+    manifest_path: Path | None = None,
+    source_path: Path | None = None,
+    skip_api: bool = False,
+    session: requests.Session | None = None,
+) -> int:
+    manifest = load_manifest(manifest_path)
+    spec = publication_spec_from_manifest(
+        manifest,
+        source_path=source_path or DEFAULT_SOURCE_CSV,
+    )
+    if not spec.source_path.is_file():
+        raise SourceError(f"source CSV not found: {spec.source_path}")
+
+    digest = verify_sha256(spec.source_path, spec.sha256)
+    print(f"source hash ok: {digest}")
+
+    source_rows = verify_source_shape(spec.source_path, spec)
+    print(
+        "complete source grid ok: "
+        f"{source_rows} rows "
+        f"{spec.source_first_timestamp}..{spec.source_last_timestamp}"
+    )
+
+    emitted = sum(1 for _ in iter_publication_rows(spec.source_path, spec))
+    print(
+        "publication slice ok: "
+        f"{emitted} rows {spec.first_timestamp}..{spec.last_timestamp}"
+    )
+
+    community_name = manifest["legacy_community_gaps"]["filename"]
+    community_path = spec.source_path.parent / community_name
+    if community_path.is_file():
+        verify_sha256(
+            community_path,
+            str(manifest["legacy_community_gaps"]["sha256"]),
+        )
+        expected_community = int(manifest["legacy_community_gaps"]["row_count"])
+        matched, total = verify_community_subset(community_path, spec.source_path)
+        print(f"community subset: {matched}/{total} exact numeric matches")
+        if total != expected_community or matched != total:
+            raise SourceError(
+                "community gap file is not an exact subset of the pinned Kaggle source"
+            )
+    else:
+        print(f"community subset: skipped ({community_path} not present)")
+
+    if skip_api:
+        print("api comparison skipped")
+        return 0
+
+    windows = verification_windows()
+    timestamps = needed_timestamps(windows)
+    source_rows = collect_source_rows(spec.source_path, timestamps)
+    budget = RequestBudget()
+    owned_session = session is None
+    session = session or requests.Session()
+    mismatches: list[Mismatch] = []
+    compared = 0
+    try:
+        for index, window in enumerate(windows):
+            api_rows = fetch_bitstamp_window(
+                window.start, window.end, budget, session=session
+            )
+            window_mismatches = compare_window(window, source_rows, api_rows)
+            window_minutes = (window.end - window.start) // MINUTE_SECONDS + 1
+            compared += window_minutes
+            status = (
+                "ok"
+                if not window_mismatches
+                else f"{len(window_mismatches)} mismatches"
+            )
+            print(
+                f"api {window.name}: {window_minutes} minutes, {status} "
+                f"(requests {budget.used}/{budget.maximum})"
+            )
+            mismatches.extend(window_mismatches)
+            if index + 1 < len(windows):
+                time.sleep(API_SLEEP_SECONDS)
+    finally:
+        if owned_session:
+            session.close()
+
+    print(f"api compared minutes: {compared}")
+    print(f"api requests used: {budget.used}")
+    if mismatches:
+        for item in mismatches[:20]:
+            when = datetime.fromtimestamp(item.timestamp, UTC).isoformat()
+            print(
+                f"  mismatch {item.window} {item.timestamp} ({when}): {item.detail}",
+                file=sys.stderr,
+            )
+        if len(mismatches) > 20:
+            print(f"  ({len(mismatches) - 20} more mismatches)", file=sys.stderr)
+        raise SourceError(f"{len(mismatches)} Bitstamp API mismatches")
+
+    print("api comparison ok")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify the pinned Kaggle snapshot against Bitstamp and local lineage."
+    )
+    parser.add_argument("--manifest", type=Path, default=None)
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument(
+        "--skip-api",
+        action="store_true",
+        help="Only check hash, publication slice, and optional community subset.",
+    )
+    args = parser.parse_args(argv)
+    try:
+        return run_verification(
+            manifest_path=args.manifest,
+            source_path=args.source,
+            skip_api=args.skip_api,
+        )
+    except (
+        OSError,
+        SourceError,
+        requests.RequestException,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(f"Source verification failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_historical_source.py
+++ b/tests/test_historical_source.py
@@ -1,0 +1,307 @@
+"""Tests for the pinned Kaggle historical builder."""
+
+import csv
+import gzip
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.historical_source import (
+    KAGGLE_HEADER,
+    PUBLIC_HEADER,
+    PublicationSpec,
+    SourceError,
+    build_historical_dataset,
+    iter_publication_rows,
+    load_manifest,
+    publication_spec_from_manifest,
+    sha256_file,
+    verify_sha256,
+    write_historical_gzip,
+)
+
+FIRST = 1_325_376_060
+SECOND = FIRST + 60
+THIRD = FIRST + 120
+FOURTH = FIRST + 180
+
+
+def _write_kaggle(
+    path: Path,
+    rows: list[list[str]],
+    header: list[str] | None = None,
+) -> str:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerow(header or list(KAGGLE_HEADER))
+        writer.writerows(rows)
+    return sha256_file(path)
+
+
+def _spec(path: Path, digest: str, **overrides: object) -> PublicationSpec:
+    values: dict[str, object] = {
+        "source_path": path,
+        "sha256": digest,
+        "header": KAGGLE_HEADER,
+        "source_first_timestamp": FIRST,
+        "source_last_timestamp": FOURTH,
+        "source_expected_rows": 4,
+        "first_timestamp": FIRST,
+        "last_timestamp": SECOND,
+        "expected_rows": 2,
+    }
+    values.update(overrides)
+    return PublicationSpec(**values)  # type: ignore[arg-type]
+
+
+def _standard_rows() -> list[list[str]]:
+    return [
+        [str(FIRST), "4.58", "4.58", "4.58", "4.58", "0.0"],
+        [str(SECOND), "4.59", "4.60", "4.59", "4.60", "1.50"],
+        [str(THIRD), "5.00", "5.00", "5.00", "5.00", "0.0"],
+        [str(FOURTH), "5.01", "5.02", "5.00", "5.01", "0.25"],
+    ]
+
+
+def test_load_manifest_publication_slice() -> None:
+    manifest = load_manifest()
+    spec = publication_spec_from_manifest(manifest)
+    assert spec.sha256 == (
+        "c3ea6522e69673da38baf88755644d546363e8a96ac60f9e7dafe003c890817f"
+    )
+    assert spec.first_timestamp == 1_325_376_060
+    assert spec.last_timestamp == 1_736_208_000
+    assert spec.expected_rows == 6_847_200
+    assert spec.header == KAGGLE_HEADER
+    assert spec.source_expected_rows == 7_710_039
+    assert (
+        spec.output_sha256
+        == "1be152060b39327b669cbed236eeb283191fadaf3862f76c1e974be54ceb1a20"
+    )
+    assert manifest["legacy_community_gaps"]["status"] == "audit_only"
+
+
+def test_hash_rejection(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(source, _standard_rows())
+    spec = _spec(source, "0" * 64)
+    with pytest.raises(SourceError, match="SHA-256 mismatch"):
+        build_historical_dataset(spec, tmp_path / "out.csv.gz")
+    verify_sha256(source, digest)
+
+
+def test_header_and_string_preservation(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(source, _standard_rows())
+    output = tmp_path / "historical.csv.gz"
+    spec = _spec(source, digest)
+    assert build_historical_dataset(spec, output) == 2
+
+    with gzip.open(output, mode="rt", encoding="utf-8", newline="") as handle:
+        rows = list(csv.reader(handle))
+    assert rows[0] == list(PUBLIC_HEADER)
+    assert rows[1] == _standard_rows()[0]
+    assert rows[2] == _standard_rows()[1]
+    assert len(rows) == 3
+
+
+def test_cutoff_excludes_trailing_source_rows(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(source, _standard_rows())
+    spec = _spec(source, digest)
+    rows = list(iter_publication_rows(source, spec))
+    assert rows == _standard_rows()[:2]
+
+
+def test_wrong_first_timestamp(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = _standard_rows()
+    rows[0][0] = str(FIRST + 60)
+    digest = _write_kaggle(source, rows)
+    spec = _spec(
+        source,
+        digest,
+        first_timestamp=FIRST,
+        last_timestamp=SECOND + 60,
+        expected_rows=2,
+    )
+    with pytest.raises(SourceError, match="expected first timestamp"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_gap_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = [_standard_rows()[0], _standard_rows()[2]]
+    digest = _write_kaggle(source, rows)
+    spec = _spec(source, digest, last_timestamp=THIRD, expected_rows=2)
+    with pytest.raises(SourceError, match="timestamp gap"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_gap_after_publication_cutoff_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = [_standard_rows()[0], _standard_rows()[1], _standard_rows()[3]]
+    digest = _write_kaggle(source, rows)
+    spec = _spec(
+        source,
+        digest,
+        source_last_timestamp=FOURTH,
+        source_expected_rows=3,
+    )
+    with pytest.raises(SourceError, match="expected timestamp"):
+        build_historical_dataset(spec, tmp_path / "out.csv.gz")
+
+
+def test_duplicate_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = [_standard_rows()[0], _standard_rows()[1], _standard_rows()[1]]
+    digest = _write_kaggle(source, rows)
+    spec = _spec(source, digest)
+    with pytest.raises(SourceError, match="duplicate timestamp"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_invalid_numeric_field_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = [[str(FIRST), "", "4.58", "4.58", "4.58", "0.0"]]
+    digest = _write_kaggle(source, rows)
+    spec = _spec(source, digest, last_timestamp=FIRST, expected_rows=1)
+    with pytest.raises(SourceError, match="empty field"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_non_finite_numeric_field_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = [[str(FIRST), "NaN", "4.58", "4.58", "4.58", "0.0"]]
+    digest = _write_kaggle(source, rows)
+    spec = _spec(source, digest, last_timestamp=FIRST, expected_rows=1)
+    with pytest.raises(SourceError, match="must be finite"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_broken_ohlc_envelope_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = [[str(FIRST), "4.58", "4.00", "4.58", "4.58", "0.0"]]
+    digest = _write_kaggle(source, rows)
+    spec = _spec(source, digest, last_timestamp=FIRST, expected_rows=1)
+    with pytest.raises(SourceError, match="high is below"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_truncated_before_cutoff(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(source, [_standard_rows()[0]])
+    spec = _spec(source, digest)
+    with pytest.raises(SourceError, match="source ended"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_wrong_header_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(
+        source,
+        _standard_rows(),
+        header=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+    spec = _spec(source, digest)
+    with pytest.raises(SourceError, match="invalid source header"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_row_before_publication_start_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    rows = [[str(FIRST - 60), "4.58", "4.58", "4.58", "4.58", "0.0"], *_standard_rows()]
+    digest = _write_kaggle(source, rows)
+    spec = _spec(source, digest)
+    with pytest.raises(SourceError, match="precedes publication start"):
+        list(iter_publication_rows(source, spec))
+
+
+def test_deterministic_gzip(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(source, _standard_rows())
+    spec = _spec(source, digest)
+    first = tmp_path / "a.csv.gz"
+    second = tmp_path / "b.csv.gz"
+    build_historical_dataset(spec, first)
+    build_historical_dataset(spec, second)
+    first_bytes = first.read_bytes()
+    second_bytes = second.read_bytes()
+    assert first_bytes == second_bytes
+    assert first_bytes[4:8] == b"\x00\x00\x00\x00"
+    assert (
+        hashlib.sha256(first_bytes).hexdigest()
+        == hashlib.sha256(second_bytes).hexdigest()
+    )
+
+
+def test_output_hash_mismatch_preserves_existing_file(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(source, _standard_rows())
+    output = tmp_path / "historical.csv.gz"
+    output.write_bytes(b"existing artifact")
+    spec = _spec(source, digest, output_sha256="0" * 64)
+
+    with pytest.raises(SourceError, match="SHA-256 mismatch"):
+        build_historical_dataset(spec, output)
+
+    assert output.read_bytes() == b"existing artifact"
+    assert not output.with_name(output.name + ".candidate").exists()
+
+
+def test_write_historical_gzip_round_trip(tmp_path: Path) -> None:
+    output = tmp_path / "out.csv.gz"
+    count = write_historical_gzip([_standard_rows()[0]], output)
+    assert count == 1
+    with gzip.open(output, mode="rt", encoding="utf-8", newline="") as handle:
+        assert next(csv.reader(handle)) == list(PUBLIC_HEADER)
+
+
+def test_preprocess_cli(tmp_path: Path) -> None:
+    source = tmp_path / "source.csv"
+    digest = _write_kaggle(source, _standard_rows())
+    manifest = tmp_path / "source-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kaggle": {
+                    "sha256": digest,
+                    "header": list(KAGGLE_HEADER),
+                    "first_timestamp": FIRST,
+                    "last_timestamp": FOURTH,
+                    "row_count": 4,
+                },
+                "publication": {
+                    "first_timestamp": FIRST,
+                    "last_timestamp": SECOND,
+                    "row_count": 2,
+                    "columns": list(PUBLIC_HEADER),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "historical.csv.gz"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/preprocess_bulk_data.py",
+            "--manifest",
+            str(manifest),
+            "--source",
+            str(source),
+            "--output",
+            str(output),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert output.is_file()
+    assert "Wrote 2 rows" in completed.stdout

--- a/tests/test_validate_dataset.py
+++ b/tests/test_validate_dataset.py
@@ -1,9 +1,8 @@
 """Tests for scripts/validate_dataset.py."""
 
-from __future__ import annotations
-
 import csv
 import gzip
+import hashlib
 import subprocess
 import sys
 from pathlib import Path
@@ -14,10 +13,12 @@ from scripts.validate_dataset import (
     COLUMN_NAMES,
     MAX_ISSUES,
     DatasetSummary,
+    expected_summary_issues,
     validate_csv_rows,
     validate_dataset,
     validate_historical_and_updates,
     validate_seam,
+    validate_sha256,
 )
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -409,6 +410,72 @@ def test_cli_failure_reports_to_stderr(tmp_path: Path) -> None:
     assert completed.returncode != 0
     assert "seam validation failed" in completed.stderr
     assert "seam mismatch" in completed.stderr
+
+
+def test_expected_summary_issues_detect_extent_mismatch() -> None:
+    summary = DatasetSummary("historical", 5, 1736207760, 1736208000)
+    issues = expected_summary_issues(
+        summary,
+        expected_first=1325376060,
+        expected_last=1736208000,
+        expected_rows=6847200,
+    )
+    messages = [issue.message for issue in issues]
+    assert any("expected 6847200 historical rows" in message for message in messages)
+    assert any("expected first timestamp" in message for message in messages)
+
+
+def test_cli_expected_summary_flags() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validate_dataset.py",
+            "--historical-tail",
+            str(HISTORICAL_TAIL),
+            "--updates",
+            str(UPDATES_HEAD),
+            "--expected-first",
+            "1736207760",
+            "--expected-last",
+            "1736208000",
+            "--expected-rows",
+            "5",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_validate_sha256() -> None:
+    expected = hashlib.sha256(HISTORICAL_TAIL.read_bytes()).hexdigest()
+    assert validate_sha256(HISTORICAL_TAIL, expected) is None
+    issue = validate_sha256(HISTORICAL_TAIL, "0" * 64)
+    assert issue is not None
+    assert "SHA-256 mismatch" in issue.message
+
+
+def test_cli_expected_checksum_failure() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validate_dataset.py",
+            "--historical-tail",
+            str(HISTORICAL_TAIL),
+            "--updates",
+            str(UPDATES_HEAD),
+            "--expected-sha256",
+            "0" * 64,
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "historical checksum mismatch" in completed.stderr
 
 
 def test_cli_file_validation_failure(tmp_path: Path) -> None:

--- a/tests/test_verify_source.py
+++ b/tests/test_verify_source.py
@@ -1,0 +1,196 @@
+"""Tests for bounded source verification helpers."""
+
+import csv
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from scripts.historical_source import (
+    KAGGLE_HEADER,
+    PUBLIC_HEADER,
+    SourceError,
+    sha256_file,
+)
+from scripts.verify_source import (
+    MAX_API_REQUESTS,
+    RequestBudget,
+    Window,
+    compare_window,
+    fetch_bitstamp_window,
+    needed_timestamps,
+    run_verification,
+    verification_windows,
+    verify_community_subset,
+)
+
+
+def test_verification_windows_stay_under_api_budget() -> None:
+    windows = verification_windows()
+    requests_needed = 0
+    for window in windows:
+        minutes = (window.end - window.start) // 60 + 1
+        requests_needed += (minutes + 999) // 1000
+    assert requests_needed < MAX_API_REQUESTS
+    assert requests_needed == len(windows)
+    names = [window.name for window in windows]
+    assert "early-2012" in names
+    assert "boundary-2024-09-13" in names
+    assert "spring-dst-2012" in names
+    assert "fall-dst-2024" in names
+    assert "seam-2025-01-07" in names
+
+
+def test_compare_window_detects_mismatch() -> None:
+    window = Window("sample", 60, 120)
+    source = {
+        60: ["60", "1.0", "1.0", "1.0", "1.0", "0.0"],
+        120: ["120", "2.0", "2.0", "2.0", "2.0", "0.5"],
+    }
+    api = {
+        60: ["60", "1.00", "1.00", "1.00", "1.00", "0.00000000"],
+        120: ["120", "2.0", "2.0", "2.0", "9.0", "0.5"],
+    }
+    mismatches = compare_window(window, source, api)
+    assert len(mismatches) == 1
+    assert mismatches[0].timestamp == 120
+
+
+def test_fetch_bitstamp_window_respects_budget() -> None:
+    session = Mock()
+    session.get.return_value.json.return_value = {
+        "data": {
+            "ohlc": [
+                {
+                    "timestamp": "60",
+                    "open": "1",
+                    "high": "1",
+                    "low": "1",
+                    "close": "1",
+                    "volume": "0",
+                }
+            ]
+        }
+    }
+    session.get.return_value.raise_for_status = Mock()
+    budget = RequestBudget(maximum=1)
+    rows = fetch_bitstamp_window(60, 60, budget, session=session)
+    assert rows[60][4] == "1"
+    with pytest.raises(SourceError, match="request budget exceeded"):
+        fetch_bitstamp_window(60, 60, budget, session=session)
+
+
+def test_fetch_bitstamp_window_rejects_malformed_payload() -> None:
+    session = Mock()
+    session.get.return_value.json.return_value = []
+    session.get.return_value.raise_for_status = Mock()
+    with pytest.raises(SourceError, match="JSON object"):
+        fetch_bitstamp_window(60, 60, RequestBudget(), session=session)
+
+
+def test_community_subset_and_api_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "btcusd_1-min_data.csv"
+    rows = [
+        ["1325376060", "4.58", "4.58", "4.58", "4.58", "0.0"],
+        ["1325376120", "4.59", "4.59", "4.59", "4.59", "0.1"],
+    ]
+    with source.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerow(KAGGLE_HEADER)
+        writer.writerows(rows)
+    community = tmp_path / "missing_ohlc_data_all_gaps_as_of_1736148000.csv"
+    with community.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerow(
+            [
+                "timestamp_unix",
+                "timestamp_utc",
+                "timestamp_ny",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+            ]
+        )
+        writer.writerow(
+            ["1325376120", "x", "y", "4.59", "4.59", "4.59", "4.59", "0.10"]
+        )
+    matched, total = verify_community_subset(community, source)
+    assert (matched, total) == (1, 1)
+
+    manifest = tmp_path / "source-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kaggle": {
+                    "sha256": sha256_file(source),
+                    "header": list(KAGGLE_HEADER),
+                    "first_timestamp": 1325376060,
+                    "last_timestamp": 1325376120,
+                    "row_count": 2,
+                },
+                "publication": {
+                    "first_timestamp": 1325376060,
+                    "last_timestamp": 1325376120,
+                    "row_count": 2,
+                    "columns": list(PUBLIC_HEADER),
+                },
+                "legacy_community_gaps": {
+                    "filename": community.name,
+                    "sha256": sha256_file(community),
+                    "row_count": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        run_verification(
+            manifest_path=manifest,
+            source_path=source,
+            skip_api=True,
+        )
+        == 0
+    )
+
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.json.return_value = {
+        "data": {
+            "ohlc": [
+                {
+                    "timestamp": row[0],
+                    "open": row[1],
+                    "high": row[2],
+                    "low": row[3],
+                    "close": row[4],
+                    "volume": row[5],
+                }
+                for row in rows
+            ]
+        }
+    }
+    session = Mock()
+    session.get.return_value = response
+    monkeypatch.setattr(
+        "scripts.verify_source.verification_windows",
+        lambda: (Window("fixture", 1325376060, 1325376120),),
+    )
+    assert (
+        run_verification(
+            manifest_path=manifest,
+            source_path=source,
+            session=session,
+        )
+        == 0
+    )
+
+
+def test_needed_timestamps_covers_inclusive_end() -> None:
+    window = Window("tiny", 60, 180)
+    assert needed_timestamps([window]) == {60, 120, 180}


### PR DESCRIPTION
## Summary
- rebuild the historical gzip from pinned Kaggle v706 data with corrected UTC minute labels
- add a deterministic, fail-closed builder plus source, checksum, extent, and seam validation
- document source attribution, timestamp interpretation, correction boundary, and reproduction steps

## Test plan
- [x] `uv run ruff format --check scripts tests`
- [x] `uv run ruff check scripts tests`
- [x] `uv run pytest -q` (54 passed)
- [x] rebuild and validate the 6,847,200-row historical artifact
- [x] verify all 106,320 community-gap rows against Kaggle v706
- [x] compare 8,304 candles across 33 bounded Bitstamp API windows

Made with [Cursor](https://cursor.com)