### PR TITLE
:bug: Stop API trailing zeros on daily CSV

### DIFF
--- a/scripts/update_data.py
+++ b/scripts/update_data.py
@@ -126,13 +126,12 @@ def fetch_and_append_missing_data(
                 f"Retrieved {len(new_data)} records for interval {start_timestamp} to {window_end}"
             )
             df_new = pd.DataFrame(new_data)
-
-            df_new["timestamp"] = pd.to_numeric(df_new["timestamp"], errors="coerce")
+            df_new.columns = COLUMN_NAMES
+            for column in COLUMN_NAMES:
+                df_new[column] = pd.to_numeric(df_new[column], errors="coerce")
             logger.debug(
                 f"Timestamp range: {df_new['timestamp'].min()} to {df_new['timestamp'].max()}"
             )
-
-            df_new.columns = COLUMN_NAMES
             logger.debug(f"Sample data:\n{df_new.head()}\n")
 
             all_new_data.append(df_new)

--- a/tests/test_update_data.py
+++ b/tests/test_update_data.py
@@ -1,0 +1,61 @@
+"""Tests for scripts/update_data.py."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+from scripts.update_data import (
+    COLUMN_NAMES,
+    fetch_and_append_missing_data,
+    fill_missing_minutes,
+)
+
+EXISTING_TS = 1_700_000_000
+NEW_TS = EXISTING_TS + 60
+
+
+def _daily_row(timestamp: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "open": [77590.0],
+            "high": [77590.0],
+            "low": [77590.0],
+            "close": [77590.0],
+            "volume": [0.0185672],
+        }
+    )
+
+
+def test_appended_rows_drop_api_trailing_zeros(tmp_path: Path) -> None:
+    daily_df = _daily_row(EXISTING_TS)
+    api_rows = [
+        {
+            "timestamp": str(NEW_TS),
+            "open": "77590.00",
+            "high": "77600.00",
+            "low": "77580.00",
+            "close": "77595.00",
+            "volume": "0.01856720",
+        }
+    ]
+
+    with patch("scripts.update_data.fetch_bitstamp_data", return_value=api_rows):
+        updated = fetch_and_append_missing_data(
+            "btcusd", (NEW_TS, NEW_TS + 60), daily_df
+        )
+    updated, _filled = fill_missing_minutes(updated)
+
+    csv_path = tmp_path / "btcusd_bitstamp_1min_latest.csv"
+    updated.to_csv(csv_path, index=False)
+    text = csv_path.read_text(encoding="utf-8")
+
+    assert list(updated.columns) == COLUMN_NAMES
+    assert "77590.00" not in text
+    assert "77600.00" not in text
+    assert "77580.00" not in text
+    assert "77595.00" not in text
+    assert "0.01856720" not in text
+    assert "77590.0,77590.0,77590.0,77590.0,0.0185672" in text
+    assert "77590.0,77600.0,77580.0,77595.0,0.0185672" in text


### PR DESCRIPTION
## Summary
- Coerce new Bitstamp OHLC and volume to numeric before concat, so daily `to_csv` no longer writes API padding (`77590.00`, `0.01856720`) next to existing float rows.
- One more daily run after this lands will still rewrite yesterday’s padded cells; after that the updates file should stay stable.

## Test plan
- [x] `uv run pytest` (110 passed)


Made with [Cursor](https://cursor.com)