### PR TITLE
:memo: Declare data licensing terms for the two history portions

### DIFF
--- a/DATA_LICENSE
+++ b/DATA_LICENSE
@@ -35,8 +35,8 @@ API by this repository's own tooling and is licensed under Creative Commons
 Attribution 4.0 International
 ([CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)).
 
-- Suggested attribution: **"Bitstamp BTC/USD minute data,
-  github.com/ff137/bitstamp-btcusd-minute-data"**.
+- Required attribution (CC BY 4.0), suggested form: **"Bitstamp BTC/USD
+  minute data, github.com/ff137/bitstamp-btcusd-minute-data"**.
 
 ## Combined artifacts
 

--- a/DATA_LICENSE
+++ b/DATA_LICENSE
@@ -1,0 +1,51 @@
+# Data licensing terms
+
+The MIT license in [LICENSE](LICENSE) covers the code in this repository
+(scripts, workflows, and documentation). The data files are subject to the
+terms below. The machine-readable acquisition record behind these terms is
+[data/original/source-manifest.json](data/original/source-manifest.json).
+
+## Kaggle-derived history (rows through Unix timestamp 1736208000)
+
+The bulk historical file
+[data/historical/btcusd_bitstamp_1min_2012-2025.csv.gz](data/historical/btcusd_bitstamp_1min_2012-2025.csv.gz)
+— every row up to and including Unix timestamp 1736208000
+(2025-01-07 00:00:00 UTC) — is derived from the Kaggle dataset
+[Bitcoin Historical Data](https://www.kaggle.com/datasets/mczielinski/bitcoin-historical-data)
+by Zielak (mczielinski), dataset version 706, licensed under Creative
+Commons Attribution-ShareAlike 4.0 International
+([CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)).
+
+- Required attribution: **"Zielak (mczielinski), Bitcoin Historical Data,
+  Kaggle"**.
+- Changes from the upstream dataset: validation, normalization to the
+  six-column schema (`timestamp,open,high,low,close,volume`), and a cut at
+  the last finalized minute before this repository's own API collection
+  begins.
+- This portion, and any adaptation of it, is distributed under
+  CC BY-SA 4.0, as ShareAlike requires.
+
+## API-collected updates (rows from Unix timestamp 1736208060 onward)
+
+Every row from Unix timestamp 1736208060 (2025-01-07 00:01:00 UTC) onward —
+the daily updates file
+[data/updates/btcusd_bitstamp_1min_latest.csv](data/updates/btcusd_bitstamp_1min_latest.csv)
+and all subsequent appends — is collected directly from the public Bitstamp
+API by this repository's own tooling and is licensed under Creative Commons
+Attribution 4.0 International
+([CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)).
+
+- Suggested attribution: **"Bitstamp BTC/USD minute data,
+  github.com/ff137/bitstamp-btcusd-minute-data"**.
+
+## Combined artifacts
+
+Any artifact that joins the two portions — for example the monthly
+full-history release assets — is an adaptation of the Kaggle-derived
+portion and is therefore distributed under CC BY-SA 4.0, with the same
+required attribution.
+
+## No affiliation
+
+Price data reflects trading on Bitstamp. This repository is not affiliated
+with, nor endorsed by, Bitstamp Ltd.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ incident. Apart from that, there were two times that the exchange was not tradin
 
 See [scripts/PROVENANCE.md](scripts/PROVENANCE.md) for more details and notes.
 
+## Data Licensing
+
+The code in this repository is MIT-licensed (see [LICENSE](LICENSE)); that
+file covers code only, not the data. The data terms are recorded in full in
+[DATA_LICENSE](DATA_LICENSE):
+
+- The bulk history (rows through Unix timestamp 1736208000, i.e. up to
+  2025-01-07 00:00 UTC) is derived from the Kaggle dataset
+  [Bitcoin Historical Data](https://www.kaggle.com/datasets/mczielinski/bitcoin-historical-data)
+  by Zielak (mczielinski), dataset version 706, and is
+  **CC BY-SA 4.0** with required attribution:
+  "Zielak (mczielinski), Bitcoin Historical Data, Kaggle".
+- The daily updates (rows from Unix timestamp 1736208060 onward) are
+  collected directly from the public Bitstamp API by this repository and
+  are **CC BY 4.0**.
+- Combined artifacts, such as the monthly full-history releases, contain
+  the Kaggle-derived portion and are therefore **CC BY-SA 4.0**.
+
+The machine-readable acquisition record lives in
+[data/original/source-manifest.json](data/original/source-manifest.json).
+
 ## How Can I Use This Data?
 
 The simplest way to use the data is to clone the repository:


### PR DESCRIPTION
## Summary

The source manifest records the bulk history as CC BY-SA 4.0
(Kaggle: Zielak/mczielinski, Bitcoin Historical Data, v706), but the
repository LICENSE is MIT and the README stated no data terms — leaving
the terms contradictory upstream and invisible to consumers.

This declares them explicitly, in a new `DATA_LICENSE` plus a README
"Data Licensing" section:

- MIT stays scoped to code only.
- Kaggle-derived rows (through Unix timestamp 1736208000, i.e.
  2025-01-07 00:00 UTC): **CC BY-SA 4.0**, required attribution
  "Zielak (mczielinski), Bitcoin Historical Data, Kaggle", changes-made
  noted, adaptations ShareAlike.
- API-collected rows (from 1736208060 onward, this repo's own
  collection): **CC BY 4.0**, attribution required, suggested form
  given.
- Combined artifacts (e.g. the monthly full-history releases) contain
  the Kaggle-derived portion and are therefore CC BY-SA 4.0.

The boundary matches the historical/updates seam exactly; the
machine-readable acquisition record is `data/original/source-manifest.json`.

No data files, schemas, or URLs change.