### PR TITLE
:bug: Type the monthly Parquet's OHLCV columns as float64

### DIFF
--- a/scripts/MONTHLY_RELEASE.md
+++ b/scripts/MONTHLY_RELEASE.md
@@ -11,7 +11,7 @@ Retry or dry-run from Actions: **Monthly snapshot release** (`workflow_dispatch`
 uv run python scripts/publish_monthly.py --year-month 2026-08 --output-dir artifacts/monthly-snapshot
 ```
 
-Assets: `btcusd_bitstamp_1min.csv.gz`, `btcusd_bitstamp_1min.parquet` (integer `timestamp`, string OHLC/volume), `btcusd_bitstamp_1min_provenance.csv` (sidecar clipped to the snapshot), `manifest.json`. Snapshot identity is the SHA-256 of the canonical manifest file.
+Assets: `btcusd_bitstamp_1min.csv.gz`, `btcusd_bitstamp_1min.parquet` (integer `timestamp`, float64 OHLC/volume), `btcusd_bitstamp_1min_provenance.csv` (sidecar clipped to the snapshot), `manifest.json`. Snapshot identity is the SHA-256 of the canonical manifest file.
 
 The first tag `bitstamp-btcusd-1m-2026-08` prepends `scripts/first_release_intro.md`. Later months do not.
 

--- a/scripts/publish_monthly.py
+++ b/scripts/publish_monthly.py
@@ -372,11 +372,11 @@ def _parquet_schema():
     return pa.schema(
         [
             ("timestamp", pa.int64()),
-            ("open", pa.string()),
-            ("high", pa.string()),
-            ("low", pa.string()),
-            ("close", pa.string()),
-            ("volume", pa.string()),
+            ("open", pa.float64()),
+            ("high", pa.float64()),
+            ("low", pa.float64()),
+            ("close", pa.float64()),
+            ("volume", pa.float64()),
         ]
     )
 
@@ -388,11 +388,10 @@ def _flush_parquet_batch(writer, rows: list[list[str]]) -> None:
         return
     arrays = [
         pa.array([int(row[0]) for row in rows], type=pa.int64()),
-        pa.array([row[1] for row in rows], type=pa.string()),
-        pa.array([row[2] for row in rows], type=pa.string()),
-        pa.array([row[3] for row in rows], type=pa.string()),
-        pa.array([row[4] for row in rows], type=pa.string()),
-        pa.array([row[5] for row in rows], type=pa.string()),
+        *(
+            pa.array([float(row[index]) for row in rows], type=pa.float64())
+            for index in range(1, 6)
+        ),
     ]
     writer.write_table(pa.Table.from_arrays(arrays, schema=_parquet_schema()))
 
@@ -449,6 +448,57 @@ def write_join_assets(
             f"expected {month.expected_candles}"
         )
     return row_count, first_timestamp, last_timestamp, stats
+
+
+def verify_parquet_matches_csv(csv_path: Path, parquet_path: Path) -> int:
+    """Fail closed unless the Parquet mirrors the csv.gz under typed parsing.
+
+    Equivalence means an identical row count and, per row, the Int64
+    timestamp and the IEEE-754 binary64 value of each OHLCV decimal text
+    field. Runs after every build so a writer regression is caught before
+    the manifest hashes the asset.
+    """
+    import pyarrow.parquet as pq
+
+    parquet_file = pq.ParquetFile(parquet_path)
+    actual_schema = parquet_file.schema_arrow
+    expected_schema = _parquet_schema()
+    if not actual_schema.equals(expected_schema):
+        found = str(actual_schema).replace("\n", ", ")
+        raise PublishError(
+            f"{parquet_path.name} schema does not match the release contract: "
+            f"found {found}"
+        )
+
+    row_count = 0
+    with open_dataset(csv_path) as handle:
+        reader = csv.reader(handle)
+        header = next(reader, None)
+        if header != list(COLUMN_NAMES):
+            raise PublishError(
+                f"{csv_path.name}: expected OHLCV header {','.join(COLUMN_NAMES)}"
+            )
+        for batch in parquet_file.iter_batches():
+            columns = [column.to_pylist() for column in batch.columns]
+            for offset in range(batch.num_rows):
+                row = next(reader, None)
+                if row is None:
+                    raise PublishError(
+                        f"{parquet_path.name} has more rows than {csv_path.name}"
+                    )
+                expected = [int(row[0]), *(float(value) for value in row[1:6])]
+                actual = [column[offset] for column in columns]
+                if actual != expected:
+                    raise PublishError(
+                        f"{parquet_path.name} row {row_count} does not match "
+                        f"{csv_path.name}: {actual!r} != {expected!r}"
+                    )
+                row_count += 1
+        if next(reader, None) is not None:
+            raise PublishError(
+                f"{csv_path.name} has more rows than {parquet_path.name}"
+            )
+    return row_count
 
 
 def _count_noun(count: int, singular: str, plural: str) -> str:
@@ -754,6 +804,11 @@ def build_snapshot(
     if first_timestamp != dataset_start:
         raise PublishError(
             f"joined first timestamp {first_timestamp} != historical start {dataset_start}"
+        )
+    verified_rows = verify_parquet_matches_csv(csv_path, parquet_path)
+    if verified_rows != row_count:
+        raise PublishError(
+            f"verified row count {verified_rows} != written row count {row_count}"
         )
 
     sidecar = read_sidecar(sidecar_path)

--- a/tests/test_publish_monthly.py
+++ b/tests/test_publish_monthly.py
@@ -70,10 +70,17 @@ def candle(timestamp: int, close: str, volume: str = "1") -> list[str]:
 def six_minute_month(
     start: int,
 ) -> tuple[MonthWindow, list[list[str]], list[list[str]]]:
+    # Real Bitstamp rows carry up to 8 decimal places; integer-valued
+    # prices would be exact even in float32, letting a writer that
+    # rounds or narrows slip past the equivalence guard.
     month = MonthWindow(2020, 1, start, start + 6 * 60)
-    historical = [candle(start + offset * 60, "100") for offset in range(3)]
+    historical = [candle(start + offset * 60, "13345.35117537") for offset in range(3)]
     updates = [
-        candle(start + (3 + offset) * 60, "110", "0" if offset == 1 else "2")
+        candle(
+            start + (3 + offset) * 60,
+            "13345.42906843",
+            "0" if offset == 1 else "5853.85216588",
+        )
         for offset in range(3)
     ]
     return month, historical, updates
@@ -304,6 +311,50 @@ def test_release_validation_refuses_string_columns(tmp_path: Path) -> None:
     pq.write_table(strung, parquet_path)
     with pytest.raises(PublishError, match="schema does not match"):
         verify_parquet_matches_csv(csv_path, parquet_path)
+
+
+def test_build_refuses_a_corrupted_parquet_before_writing_the_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The equivalence guard is wired into the build, ahead of the manifest.
+
+    A writer that damages the Parquet must fail the whole build, and the
+    failure must land before manifest.json exists -- otherwise the guard
+    could be unhooked, or moved below the hash step, without any test
+    noticing.
+    """
+    from scripts import publish_monthly
+
+    real_flush = publish_monthly._flush_parquet_batch
+
+    def corrupting_flush(writer, rows: list[list[str]]) -> None:
+        damaged = [list(row) for row in rows]
+        if damaged:
+            damaged[0][4] = str(float(damaged[0][4]) + 0.5)
+        real_flush(writer, damaged)
+
+    monkeypatch.setattr(publish_monthly, "_flush_parquet_batch", corrupting_flush)
+
+    start = 1_577_836_800
+    month, historical_rows, updates_rows = six_minute_month(start)
+    historical, updates = write_pair(tmp_path, historical_rows, updates_rows)
+    sidecar = tmp_path / "sidecar.csv"
+    write_sidecar(sidecar, [])
+    intro = tmp_path / "intro.md"
+    intro.write_text("x\n", encoding="utf-8")
+
+    with pytest.raises(PublishError, match="row 0 does not match"):
+        build_snapshot(
+            month=month,
+            historical_path=historical,
+            updates_path=updates,
+            sidecar_path=sidecar,
+            intro_path=intro,
+            output_dir=tmp_path / "out",
+            as_of="2026-09-01T00:10:00Z",
+            generation_revision="deadbeef",
+        )
+    assert not (tmp_path / "out" / "manifest.json").exists()
 
 
 def test_short_tail_fails(tmp_path: Path) -> None:

--- a/tests/test_publish_monthly.py
+++ b/tests/test_publish_monthly.py
@@ -187,6 +187,125 @@ def test_join_cutoff_and_parquet(tmp_path: Path) -> None:
     assert "updater:fill_missing_minutes" not in result.notes
 
 
+def build_six_minute_snapshot(tmp_path: Path) -> Path:
+    start = 1_577_836_800
+    month, historical_rows, updates_rows = six_minute_month(start)
+    historical, updates = write_pair(tmp_path, historical_rows, updates_rows)
+    sidecar = tmp_path / "sidecar.csv"
+    write_sidecar(sidecar, [])
+    intro = tmp_path / "intro.md"
+    intro.write_text("x\n", encoding="utf-8")
+    build_snapshot(
+        month=month,
+        historical_path=historical,
+        updates_path=updates,
+        sidecar_path=sidecar,
+        intro_path=intro,
+        output_dir=tmp_path / "out",
+        as_of="2026-09-01T00:10:00Z",
+        generation_revision="deadbeef",
+    )
+    return tmp_path / "out"
+
+
+def test_parquet_ohlcv_columns_are_typed(tmp_path: Path) -> None:
+    """The Parquet asset carries typed numerics, not the CSV's decimal text."""
+    start = 1_577_836_800
+    month = MonthWindow(2020, 1, start, start + 6 * 60)
+    historical_rows = [
+        [str(start), "7160.03", "7161.5", "7159.9", "7160.5", "0.06"],
+        [str(start + 60), "7160.5", "7162.1", "7160.0", "7161.0", "1.5"],
+        [str(start + 120), "7161.0", "7161.0", "7160.1", "7160.1", "0.75"],
+    ]
+    updates_rows = [
+        [str(start + 180), "7160.1", "7163.3", "7160.1", "7163.0", "2.25"],
+        [str(start + 240), "7163.0", "7163.0", "7162.2", "7162.5", "0.1"],
+        [str(start + 300), "7162.5", "7164.0", "7162.5", "7163.9", "3"],
+    ]
+    historical, updates = write_pair(tmp_path, historical_rows, updates_rows)
+    sidecar = tmp_path / "sidecar.csv"
+    write_sidecar(sidecar, [])
+    intro = tmp_path / "intro.md"
+    intro.write_text("x\n", encoding="utf-8")
+
+    result = build_snapshot(
+        month=month,
+        historical_path=historical,
+        updates_path=updates,
+        sidecar_path=sidecar,
+        intro_path=intro,
+        output_dir=tmp_path / "out",
+        as_of="2026-09-01T00:10:00Z",
+        generation_revision="deadbeef",
+    )
+
+    assert result.row_count == 6
+    table = pq.read_table(tmp_path / "out" / "btcusd_bitstamp_1min.parquet")
+    expected_schema = pa.schema(
+        [("timestamp", pa.int64())]
+        + [(name, pa.float64()) for name in OHLCV_HEADER[1:]]
+    )
+    assert table.schema.equals(expected_schema), str(table.schema)
+    all_rows = historical_rows + updates_rows
+    assert table.column("timestamp").to_pylist() == [int(row[0]) for row in all_rows]
+    for index, name in enumerate(OHLCV_HEADER[1:], start=1):
+        expected_values = [float(row[index]) for row in all_rows]
+        assert table.column(name).to_pylist() == expected_values, name
+
+
+def test_release_validation_pins_parquet_to_csv(tmp_path: Path) -> None:
+    """The post-build check accepts the built pair and refuses a doctored one."""
+    from scripts.publish_monthly import verify_parquet_matches_csv
+
+    output_dir = build_six_minute_snapshot(tmp_path)
+    csv_path = output_dir / "btcusd_bitstamp_1min.csv.gz"
+    parquet_path = output_dir / "btcusd_bitstamp_1min.parquet"
+
+    assert verify_parquet_matches_csv(csv_path, parquet_path) == 6
+
+    table = pq.read_table(parquet_path)
+    doctored_close = table.column("close").to_pylist()
+    doctored_close[3] += 0.5
+    doctored = table.set_column(
+        table.schema.get_field_index("close"),
+        "close",
+        pa.array(doctored_close, type=pa.float64()),
+    )
+    pq.write_table(doctored, parquet_path)
+    with pytest.raises(PublishError, match="row 3 does not match"):
+        verify_parquet_matches_csv(csv_path, parquet_path)
+
+    pq.write_table(table.slice(0, 5), parquet_path)
+    with pytest.raises(PublishError, match="more rows than"):
+        verify_parquet_matches_csv(csv_path, parquet_path)
+
+
+def test_release_validation_refuses_string_columns(tmp_path: Path) -> None:
+    """A Parquet with string OHLCV columns must be refused outright."""
+    from scripts.publish_monthly import verify_parquet_matches_csv
+
+    output_dir = build_six_minute_snapshot(tmp_path)
+    csv_path = output_dir / "btcusd_bitstamp_1min.csv.gz"
+    parquet_path = output_dir / "btcusd_bitstamp_1min.parquet"
+
+    table = pq.read_table(parquet_path)
+    strung = pa.table(
+        {
+            "timestamp": table.column("timestamp"),
+            **{
+                name: pa.array(
+                    [format(value, "g") for value in table.column(name).to_pylist()],
+                    type=pa.string(),
+                )
+                for name in OHLCV_HEADER[1:]
+            },
+        }
+    )
+    pq.write_table(strung, parquet_path)
+    with pytest.raises(PublishError, match="schema does not match"):
+        verify_parquet_matches_csv(csv_path, parquet_path)
+
+
 def test_short_tail_fails(tmp_path: Path) -> None:
     start = 1_577_836_800
     month, historical_rows, updates_rows = six_minute_month(start)


### PR DESCRIPTION
The `bitstamp-btcusd-1m-2026-08` release's Parquet asset carries its five OHLCV columns as strings — the CSV's decimal text verbatim — because the writer schema declared them `pa.string()`. An OHLCV Parquet should carry typed numerics.

## Changes

- Declare `timestamp` int64 and `open`/`high`/`low`/`close`/`volume` float64 in the writer schema, and cast each batch from the CSV text accordingly.
- Add a fail-closed post-build check, `verify_parquet_matches_csv`, that re-reads both written assets and requires an identical row count and, per row, the int64 timestamp and the IEEE-754 binary64 value of each decimal text field — before the manifest hashes the assets. A schema regression of the shipped kind now fails the build instead of releasing.
- Pin the typed schema and value equivalence, plus three refusal modes: a string-typed schema, one altered cell, and a truncated file.

## Verification

- Full test suite: 113 passed; ruff check and format clean.
- Full local 2026-08 rebuild (build only, no release created): 7,714,079 rows, schema `timestamp int64` + five `float64` columns, equivalence check passed end to end in a 1m51s build.

The already-published 2026-08 asset still has string columns; whether to re-cut it or note an erratum is a separate decision and out of scope here.