### PR TITLE
:sparkles: Month-leading release titles and a typed-Parquet builder

### DIFF
--- a/scripts/backfill_typed_parquet.py
+++ b/scripts/backfill_typed_parquet.py
@@ -1,0 +1,65 @@
+"""Write a typed Parquet from a release's csv.gz and prove equivalence.
+
+The bitstamp-btcusd-1m-2026-08 release shipped its Parquet with string
+OHLCV columns. The published asset stays as it is; this script builds a
+correctly typed companion (timestamp int64, OHLCV float64) from the
+release's own csv.gz and refuses to emit it unless
+``verify_parquet_matches_csv`` passes — the same fail-closed check the
+monthly build runs.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.publish_monthly import (
+    PARQUET_BATCH_SIZE,
+    PublishError,
+    _flush_parquet_batch,
+    _parquet_schema,
+    iter_ohlcv_rows,
+    verify_parquet_matches_csv,
+)
+
+
+def write_typed_parquet(csv_path: Path, parquet_path: Path) -> int:
+    """Build a typed Parquet from ``csv_path`` and return the verified row count."""
+    import pyarrow.parquet as pq
+
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    batch: list[list[str]] = []
+    with pq.ParquetWriter(
+        parquet_path, _parquet_schema(), compression="zstd"
+    ) as writer:
+        for row in iter_ohlcv_rows(csv_path):
+            if len(row) != 6:
+                raise PublishError(f"expected 6 OHLCV columns, found {len(row)}")
+            batch.append(row)
+            if len(batch) >= PARQUET_BATCH_SIZE:
+                _flush_parquet_batch(writer, batch)
+                batch = []
+        _flush_parquet_batch(writer, batch)
+    return verify_parquet_matches_csv(csv_path, parquet_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a typed Parquet from a release csv.gz, fail-closed.",
+    )
+    parser.add_argument("csv_path", type=Path)
+    parser.add_argument("parquet_path", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        rows = write_typed_parquet(args.csv_path, args.parquet_path)
+    except PublishError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"{args.parquet_path}: {rows} rows, verified against {args.csv_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_typed_parquet.py
+++ b/scripts/backfill_typed_parquet.py
@@ -3,9 +3,11 @@
 The bitstamp-btcusd-1m-2026-08 release shipped its Parquet with string
 OHLCV columns. The published asset stays as it is; this script builds a
 correctly typed companion (timestamp int64, OHLCV float64) from the
-release's own csv.gz and refuses to emit it unless
-``verify_parquet_matches_csv`` passes — the same fail-closed check the
-monthly build runs.
+release's own csv.gz. It writes to a temporary sibling path and moves
+the file to the requested output only after
+``verify_parquet_matches_csv`` — the same fail-closed check the monthly
+build runs — has passed, so a failed run leaves nothing at the output
+path (and never disturbs a file already there).
 """
 
 import argparse
@@ -26,23 +28,37 @@ from scripts.publish_monthly import (
 
 
 def write_typed_parquet(csv_path: Path, parquet_path: Path) -> int:
-    """Build a typed Parquet from ``csv_path`` and return the verified row count."""
+    """Build a typed Parquet from ``csv_path`` and return the verified row count.
+
+    Nothing reaches ``parquet_path`` unless verification passes: the file
+    is written to a temporary sibling, verified there, and renamed into
+    place, so a failure leaves the output path exactly as it was.
+    """
+    import os
+
     import pyarrow.parquet as pq
 
     parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    staging_path = parquet_path.with_name(parquet_path.name + ".unverified")
     batch: list[list[str]] = []
-    with pq.ParquetWriter(
-        parquet_path, _parquet_schema(), compression="zstd"
-    ) as writer:
-        for row in iter_ohlcv_rows(csv_path):
-            if len(row) != 6:
-                raise PublishError(f"expected 6 OHLCV columns, found {len(row)}")
-            batch.append(row)
-            if len(batch) >= PARQUET_BATCH_SIZE:
-                _flush_parquet_batch(writer, batch)
-                batch = []
-        _flush_parquet_batch(writer, batch)
-    return verify_parquet_matches_csv(csv_path, parquet_path)
+    try:
+        with pq.ParquetWriter(
+            staging_path, _parquet_schema(), compression="zstd"
+        ) as writer:
+            for row in iter_ohlcv_rows(csv_path):
+                if len(row) != 6:
+                    raise PublishError(f"expected 6 OHLCV columns, found {len(row)}")
+                batch.append(row)
+                if len(batch) >= PARQUET_BATCH_SIZE:
+                    _flush_parquet_batch(writer, batch)
+                    batch = []
+            _flush_parquet_batch(writer, batch)
+        row_count = verify_parquet_matches_csv(csv_path, staging_path)
+    except BaseException:
+        staging_path.unlink(missing_ok=True)
+        raise
+    os.replace(staging_path, parquet_path)
+    return row_count
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/publish_monthly.py
+++ b/scripts/publish_monthly.py
@@ -735,13 +735,19 @@ def load_intro(path: Path, tag: str) -> str | None:
     return text
 
 
+def release_title(tag: str) -> str:
+    """Lead with the month: GitHub truncates long titles in release lists,
+    so the distinguishing part must come first."""
+    return f"{tag.removeprefix(TAG_PREFIX)} · Bitstamp BTC/USD 1-minute"
+
+
 def create_github_release(
     *,
     tag: str,
     notes_path: Path,
     output_dir: Path,
 ) -> None:
-    title = f"Bitstamp BTC/USD 1-minute · {tag.removeprefix(TAG_PREFIX)}"
+    title = release_title(tag)
     files = [
         output_dir / CSV_ASSET,
         output_dir / PARQUET_ASSET,

--- a/tests/test_backfill_typed_parquet.py
+++ b/tests/test_backfill_typed_parquet.py
@@ -1,0 +1,55 @@
+"""Tests for scripts/backfill_typed_parquet.py."""
+
+import csv
+import gzip
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from scripts.backfill_typed_parquet import main, write_typed_parquet
+from scripts.validate_dataset import COLUMN_NAMES
+
+ROWS = [
+    ["1577836800", "13345.35117537", "13346.1", "13345.0", "13345.42906843", "0.06"],
+    ["1577836860", "13345.42906843", "13345.5", "13344.9", "13345.1", "5853.85216588"],
+]
+
+
+def write_csv_gz(path: Path) -> None:
+    with gzip.open(path, mode="wt", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerow(COLUMN_NAMES)
+        writer.writerows(ROWS)
+
+
+def test_write_typed_parquet_builds_and_verifies(tmp_path: Path) -> None:
+    csv_path = tmp_path / "release.csv.gz"
+    write_csv_gz(csv_path)
+    parquet_path = tmp_path / "typed.parquet"
+
+    assert write_typed_parquet(csv_path, parquet_path) == 2
+
+    table = pq.read_table(parquet_path)
+    assert table.schema.field("timestamp").type == pa.int64()
+    for name in COLUMN_NAMES[1:]:
+        assert table.schema.field(name).type == pa.float64(), name
+    assert table.column("timestamp").to_pylist() == [int(row[0]) for row in ROWS]
+    assert table.column("close").to_pylist() == [float(row[4]) for row in ROWS]
+    assert table.column("volume").to_pylist() == [float(row[5]) for row in ROWS]
+
+
+def test_main_reports_the_verified_count_and_fails_closed(
+    tmp_path: Path, capsys
+) -> None:
+    csv_path = tmp_path / "release.csv.gz"
+    write_csv_gz(csv_path)
+    parquet_path = tmp_path / "typed.parquet"
+
+    assert main([str(csv_path), str(parquet_path)]) == 0
+    assert "2 rows" in capsys.readouterr().out
+
+    bad = tmp_path / "bad.csv.gz"
+    with gzip.open(bad, mode="wt", encoding="utf-8", newline="") as handle:
+        handle.write("not,a,valid,header\n")
+    assert main([str(bad), str(tmp_path / "bad.parquet")]) == 1

--- a/tests/test_backfill_typed_parquet.py
+++ b/tests/test_backfill_typed_parquet.py
@@ -53,3 +53,42 @@ def test_main_reports_the_verified_count_and_fails_closed(
     with gzip.open(bad, mode="wt", encoding="utf-8", newline="") as handle:
         handle.write("not,a,valid,header\n")
     assert main([str(bad), str(tmp_path / "bad.parquet")]) == 1
+
+
+def test_a_corrupting_writer_fails_the_run_and_leaves_no_output(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """The equivalence guard is wired in, and failure emits nothing.
+
+    A writer that damages a value must fail the run through the guard
+    (not an upstream header check), and the output path must be left
+    exactly as it was -- absent, or holding its previous content -- so a
+    failed rerun can never plant a wrong file where a later upload
+    expects a verified one.
+    """
+    import scripts.backfill_typed_parquet as backfill
+    from scripts import publish_monthly
+
+    real_flush = publish_monthly._flush_parquet_batch
+
+    def corrupting_flush(writer, rows: list[list[str]]) -> None:
+        damaged = [list(row) for row in rows]
+        if damaged:
+            damaged[0][4] = str(float(damaged[0][4]) + 0.5)
+        real_flush(writer, damaged)
+
+    monkeypatch.setattr(backfill, "_flush_parquet_batch", corrupting_flush)
+
+    csv_path = tmp_path / "release.csv.gz"
+    write_csv_gz(csv_path)
+    parquet_path = tmp_path / "typed.parquet"
+
+    assert main([str(csv_path), str(parquet_path)]) == 1
+    assert "does not match" in capsys.readouterr().err
+    assert not parquet_path.exists()
+    assert list(tmp_path.glob("*.unverified")) == []
+
+    decoy = b"previous verified bytes"
+    parquet_path.write_bytes(decoy)
+    assert main([str(csv_path), str(parquet_path)]) == 1
+    assert parquet_path.read_bytes() == decoy

--- a/tests/test_publish_monthly.py
+++ b/tests/test_publish_monthly.py
@@ -38,6 +38,7 @@ from scripts.publish_monthly import (
     month_window,
     parse_year_month,
     previous_utc_month,
+    release_title,
     render_notes,
     run_publish,
     sha256_file,
@@ -117,6 +118,14 @@ def test_previous_month_and_first_day() -> None:
 def test_parse_year_month_rejects_garbage() -> None:
     with pytest.raises(PublishError):
         parse_year_month("2026/08")
+
+
+def test_release_title_leads_with_the_month() -> None:
+    """GitHub truncates release titles; the month must come first."""
+    assert (
+        release_title("bitstamp-btcusd-1m-2026-08")
+        == "2026-08 · Bitstamp BTC/USD 1-minute"
+    )
 
 
 def test_volume_thousand_separators() -> None:


### PR DESCRIPTION
Two additive changes around the 2026-08 release's string-typed Parquet (kept as published — nothing here mutates an existing asset):

## Changes

- **Release titles lead with the month.** Every title began with the same 28 characters, so GitHub's truncated release list showed identical entries. `release_title()` now produces `2026-08 · Bitstamp BTC/USD 1-minute`, pinned by a test. Existing release titles will be updated in place (title text is metadata; tags are untouched).
- **`scripts/backfill_typed_parquet.py`** builds a correctly typed companion Parquet (timestamp int64, OHLCV float64) from a release's own csv.gz, reusing the monthly build's schema and batch writer. The file is written to a temporary sibling, verified there with `verify_parquet_matches_csv` — the same fail-closed equivalence check the build runs — and renamed into place only on success, so a failed run leaves nothing at the output path. This generates the corrected asset to be attached alongside the 2026-08 original under a distinct filename, with the release description carrying the erratum.

## Verification

- 117 passed (three new tests: title format, builder schema+values, fail-closed exit); ruff check and format clean.
